### PR TITLE
Utility menu rewrite

### DIFF
--- a/src/main/java/com/dragonminez/client/gui/UtilityMenuScreen.java
+++ b/src/main/java/com/dragonminez/client/gui/UtilityMenuScreen.java
@@ -4,18 +4,11 @@ import com.dragonminez.client.gui.utilitymenu.ButtonInfo;
 import com.dragonminez.client.gui.utilitymenu.IUtilityMenuSlot;
 import com.dragonminez.client.gui.utilitymenu.menuslots.*;
 import com.dragonminez.client.util.KeyBinds;
-import com.dragonminez.common.init.MainSounds;
-import com.dragonminez.common.network.C2S.ExecuteActionC2S;
-import com.dragonminez.common.network.C2S.SwitchActionC2S;
-import com.dragonminez.common.network.NetworkHandler;
-import com.dragonminez.common.stats.ActionMode;
 import com.dragonminez.common.stats.StatsCapability;
 import com.dragonminez.common.stats.StatsData;
 import com.dragonminez.common.stats.StatsProvider;
-import com.dragonminez.common.util.TransformationsHelper;
 import com.mojang.blaze3d.platform.InputConstants;
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
@@ -28,15 +21,23 @@ import java.util.List;
 
 @OnlyIn(Dist.CLIENT)
 public class UtilityMenuScreen extends Screen {
-	private List<IUtilityMenuSlot> menuSlots = new ArrayList<>();
+	private static final List<IUtilityMenuSlot> MENU_SLOTS = new ArrayList<>();
+	private static final List<IUtilityMenuSlot> ADDON_SLOTS = new ArrayList<>();
+	private static final int[][] POSITIONS = {
+			{-2, -1}, {-1, -1}, {0, -1}, {1, -1}, {2, -1},
+			{-2,  0}, {-1,  0},          {1,  0}, {2,  0},
+			{-2,  1}, {-1,  1}, {0,  1}, {1,  1}, {2,  1}
+	};
+	private static final long ANIMATION_DURATION = 100;
+	// Default button width is 105, but proves too large for GUI Scale AUTO
+	// and GUI Scale 4 when using 14 slot positions
+	private static final int BUTTON_WIDTH = 90;
+	private static final int BUTTON_HEIGHT = 70;
+	private static final int GAP = 5;
 
 	private long openTime;
-	private static final long ANIMATION_DURATION = 100;
 	private StatsData statsData;
 
-	private final int BUTTON_WIDTH = 105;
-	private final int BUTTON_HEIGHT = 70;
-	private final int GAP = 5;
 
 	public UtilityMenuScreen() {
 		super(Component.literal("Menu"));
@@ -51,15 +52,8 @@ public class UtilityMenuScreen extends Screen {
 			StatsProvider.get(StatsCapability.INSTANCE, mc.player).ifPresent(data -> this.statsData = data);
 		}
 
-		IUtilityMenuSlot emptySlot = new EmptyMenuSlot();
-		menuSlots.add(0, new KaiokenMenuSlot());
-		menuSlots.add(1, new SuperformMenuSlot());
-		menuSlots.add(2, new FusionMenuSlot());
-		menuSlots.add(3, emptySlot);
-		menuSlots.add(4, emptySlot);
-		menuSlots.add(5, new KiManipulationMenuSlot());
-		menuSlots.add(6, new RacialActionMenuSlot());
-		menuSlots.add(7, new DescendFormMenuSlot());
+		// FIXME: This should be moved to a mod loading event, perhaps post init
+		initMenuSlots();
 	}
 
 	@Override
@@ -90,15 +84,9 @@ public class UtilityMenuScreen extends Screen {
 	}
 
 	private void renderGrid(GuiGraphics graphics, int centerX, int centerY, int mouseX, int mouseY) {
-		int[][] positions = {
-				{-1, -1}, {0, -1}, {1, -1},
-				{-1, 0},           {1, 0},
-				{-1, 1},  {0, 1},  {1, 1}
-		};
-
-		for (int i = 0; i < 8; i++) {
-			int col = positions[i][0];
-			int row = positions[i][1];
+		for (int i = 0; i < POSITIONS.length; i++) {
+			int col = POSITIONS[i][0];
+			int row = POSITIONS[i][1];
 
 			int x = centerX + (col * (BUTTON_WIDTH + GAP)) - (BUTTON_WIDTH / 2);
 			int y = centerY + (row * (BUTTON_HEIGHT + GAP)) - (BUTTON_HEIGHT / 2);
@@ -113,7 +101,7 @@ public class UtilityMenuScreen extends Screen {
 	}
 
 	private void renderButtonContent(GuiGraphics graphics, int index, int x, int y) {
-		IUtilityMenuSlot menuSlot = menuSlots.get(index);
+		IUtilityMenuSlot menuSlot = MENU_SLOTS.get(index);
 		if (menuSlot != null) {
 			ButtonInfo buttonInfo = menuSlot.render(statsData);
 			if (buttonInfo != null) {
@@ -122,9 +110,13 @@ public class UtilityMenuScreen extends Screen {
 				}
 
 				if (!buttonInfo.getLine1().getString().isEmpty()) {
-					drawCenteredStringWithBorder(graphics, buttonInfo.getLine1(), x + BUTTON_WIDTH / 2, y + 12, 0xFFFFFF, 0x000000);
-					if (index == 5) graphics.drawCenteredString(font, buttonInfo.getLine2(), x + BUTTON_WIDTH / 2, y + 30, statsData.getSkills().isSkillActive("kimanipulation") ? 0x2BFF00 : 0xFF1B00);
-					else graphics.drawCenteredString(font, buttonInfo.getLine2(), x + BUTTON_WIDTH / 2, y + 30, buttonInfo.isSelected() ? buttonInfo.getColor() : 0xFF1B00);
+					this.drawCenteredStringWithBorder(graphics, buttonInfo.getLine1(), x + BUTTON_WIDTH / 2, y + 12, 0xFFFFFF, 0x000000);
+					if (index == 5) {
+						graphics.drawCenteredString(font, buttonInfo.getLine2(), x + BUTTON_WIDTH / 2, y + 30, statsData.getSkills().isSkillActive("kimanipulation") ? 0x2BFF00 : 0xFF1B00);
+					}
+					else {
+						graphics.drawCenteredString(font, buttonInfo.getLine2(), x + BUTTON_WIDTH / 2, y + 30, buttonInfo.isSelected() ? buttonInfo.getColor() : 0xFF1B00);
+					}
 				}
 			}
 		}
@@ -135,15 +127,9 @@ public class UtilityMenuScreen extends Screen {
 		int centerX = this.width / 2;
 		int centerY = this.height / 2;
 
-		int[][] positions = {
-				{-1, -1}, {0, -1}, {1, -1},
-				{-1, 0},           {1, 0},
-				{-1, 1},  {0, 1},  {1, 1}
-		};
-
-		for (int i = 0; i < 8; i++) {
-			int col = positions[i][0];
-			int row = positions[i][1];
+		for (int i = 0; i < POSITIONS.length; i++) {
+			int col = POSITIONS[i][0];
+			int row = POSITIONS[i][1];
 
 			int x = centerX + (col * (BUTTON_WIDTH + GAP)) - (BUTTON_WIDTH / 2);
 			int y = centerY + (row * (BUTTON_HEIGHT + GAP)) - (BUTTON_HEIGHT / 2);
@@ -157,7 +143,7 @@ public class UtilityMenuScreen extends Screen {
 	}
 
 	private void handleSlotClick(int index) {
-		IUtilityMenuSlot menuSlot = menuSlots.get(index);
+		IUtilityMenuSlot menuSlot = MENU_SLOTS.get(index);
 		if (menuSlot != null) {
 			menuSlot.handle(statsData);
 		}
@@ -184,5 +170,30 @@ public class UtilityMenuScreen extends Screen {
 		graphics.drawString(font, text, x - font.width(text) / 2, y - 1, borderColor, false);
 		graphics.drawString(font, text, x - font.width(text) / 2, y + 1, borderColor, false);
 		graphics.drawString(font, text, x - font.width(text) / 2, y, color, false);
+	}
+
+	public static void initMenuSlots() {
+		if (MENU_SLOTS.isEmpty()) {
+			MENU_SLOTS.add(0, new KaiokenMenuSlot());
+			MENU_SLOTS.add(1, new SuperformMenuSlot());
+			MENU_SLOTS.add(2, new FusionMenuSlot());
+			MENU_SLOTS.add(3, new EmptyMenuSlot());
+			MENU_SLOTS.add(4, new EmptyMenuSlot());
+			MENU_SLOTS.add(5, new KiManipulationMenuSlot());
+			MENU_SLOTS.add(6, new RacialActionMenuSlot());
+			MENU_SLOTS.add(7, new DescendFormMenuSlot());
+			if (!ADDON_SLOTS.isEmpty()) {
+				for (int i = MENU_SLOTS.size(), e = 0; i < POSITIONS.length && e <= ADDON_SLOTS.size(); i++, e++) {
+					MENU_SLOTS.add(i, ADDON_SLOTS.get(e));
+				}
+			}
+			for (int i = MENU_SLOTS.size(); i < POSITIONS.length; i++) {
+				MENU_SLOTS.add(i, new EmptyMenuSlot());
+			}
+		}
+	}
+
+	public static void addMenuSlot(IUtilityMenuSlot menuSlot) {
+		ADDON_SLOTS.add(menuSlot);
 	}
 }

--- a/src/main/java/com/dragonminez/client/gui/UtilityMenuScreen.java
+++ b/src/main/java/com/dragonminez/client/gui/UtilityMenuScreen.java
@@ -51,9 +51,12 @@ public class UtilityMenuScreen extends Screen {
 			StatsProvider.get(StatsCapability.INSTANCE, mc.player).ifPresent(data -> this.statsData = data);
 		}
 
+		IUtilityMenuSlot emptySlot = new EmptyMenuSlot();
 		menuSlots.add(0, new KaiokenMenuSlot());
 		menuSlots.add(1, new SuperformMenuSlot());
 		menuSlots.add(2, new FusionMenuSlot());
+		menuSlots.add(3, emptySlot);
+		menuSlots.add(4, emptySlot);
 		menuSlots.add(5, new KiManipulationMenuSlot());
 		menuSlots.add(6, new RacialActionMenuSlot());
 		menuSlots.add(7, new DescendFormMenuSlot());

--- a/src/main/java/com/dragonminez/client/gui/UtilityMenuScreen.java
+++ b/src/main/java/com/dragonminez/client/gui/UtilityMenuScreen.java
@@ -1,5 +1,8 @@
 package com.dragonminez.client.gui;
 
+import com.dragonminez.client.gui.utilitymenu.ButtonInfo;
+import com.dragonminez.client.gui.utilitymenu.IUtilityMenuSlot;
+import com.dragonminez.client.gui.utilitymenu.menuslots.*;
 import com.dragonminez.client.util.KeyBinds;
 import com.dragonminez.common.init.MainSounds;
 import com.dragonminez.common.network.C2S.ExecuteActionC2S;
@@ -20,8 +23,12 @@ import net.minecraft.network.chat.Component;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @OnlyIn(Dist.CLIENT)
 public class UtilityMenuScreen extends Screen {
+	private List<IUtilityMenuSlot> menuSlots = new ArrayList<>();
 
 	private long openTime;
 	private static final long ANIMATION_DURATION = 100;
@@ -43,6 +50,13 @@ public class UtilityMenuScreen extends Screen {
 		if (mc.player != null) {
 			StatsProvider.get(StatsCapability.INSTANCE, mc.player).ifPresent(data -> this.statsData = data);
 		}
+
+		menuSlots.add(0, new KaiokenMenuSlot());
+		menuSlots.add(1, new SuperformMenuSlot());
+		menuSlots.add(2, new FusionMenuSlot());
+		menuSlots.add(5, new KiManipulationMenuSlot());
+		menuSlots.add(6, new RacialActionMenuSlot());
+		menuSlots.add(7, new DescendFormMenuSlot());
 	}
 
 	@Override
@@ -96,68 +110,20 @@ public class UtilityMenuScreen extends Screen {
 	}
 
 	private void renderButtonContent(GuiGraphics graphics, int index, int x, int y) {
-		Component line1 = Component.empty();
-		Component line2 = Component.empty();
-		int color = 0xFFFFFF;
-		boolean isSelected = false;
+		IUtilityMenuSlot menuSlot = menuSlots.get(index);
+		if (menuSlot != null) {
+			ButtonInfo buttonInfo = menuSlot.render(statsData);
+			if (buttonInfo != null) {
+				if (buttonInfo.isSelected()) {
+					buttonInfo.setColor(0x2BFF00);
+				}
 
-		ActionMode currentMode = statsData.getStatus().getSelectedAction();
-		String race = statsData.getCharacter().getRaceName();
-
-		switch (index) {
-			case 0 -> {
-				if (statsData.getSkills().hasSkill("kaioken")) {
-					line1 = Component.translatable("gui.action.dragonminez.kaioken").withStyle(ChatFormatting.BOLD);
-					line2 = Component.translatable("gui.action.dragonminez." + (statsData.getStatus().getSelectedAction() == ActionMode.KAIOKEN ? "true" : "false"));
-					isSelected = currentMode == ActionMode.KAIOKEN;
+				if (!buttonInfo.getLine1().getString().isEmpty()) {
+					drawCenteredStringWithBorder(graphics, buttonInfo.getLine1(), x + BUTTON_WIDTH / 2, y + 12, 0xFFFFFF, 0x000000);
+					if (index == 5) graphics.drawCenteredString(font, buttonInfo.getLine2(), x + BUTTON_WIDTH / 2, y + 30, statsData.getSkills().isSkillActive("kimanipulation") ? 0x2BFF00 : 0xFF1B00);
+					else graphics.drawCenteredString(font, buttonInfo.getLine2(), x + BUTTON_WIDTH / 2, y + 30, buttonInfo.isSelected() ? buttonInfo.getColor() : 0xFF1B00);
 				}
 			}
-			case 1 -> {
-				if (statsData.getSkills().getSkillLevel("superform") >= 1 || statsData.getSkills().getSkillLevel("legendaryforms") >= 1 || statsData.getSkills().getSkillLevel("godform") >= 1 || statsData.getSkills().getSkillLevel("androidforms") >= 1) {
-					line1 = Component.translatable("race.dragonminez." + race + ".group." + statsData.getCharacter().getSelectedFormGroup()).withStyle(ChatFormatting.BOLD);
-					line2 = Component.translatable("race.dragonminez." + race + ".form." + statsData.getCharacter().getSelectedFormGroup() + "." + TransformationsHelper.getFirstFormGroup(statsData.getCharacter().getSelectedFormGroup(), race));
-					isSelected = currentMode == ActionMode.FORM;
-				}
-			}
-			case 2 -> {
-				if (statsData.getSkills().hasSkill("fusion")) {
-					line1 = Component.translatable("gui.action.dragonminez.fusion").withStyle(ChatFormatting.BOLD);
-					line2 = Component.translatable("gui.action.dragonminez." + (statsData.getStatus().getSelectedAction() == ActionMode.FUSION ? "true" : "false"));
-					isSelected = currentMode == ActionMode.FUSION;
-				}
-			}
-			case 5 -> {
-				if (statsData.getSkills().hasSkill("kimanipulation") && statsData.getSkills().hasSkill("kicontrol")) {
-					String weaponType = statsData.getStatus().getKiWeaponType();
-					line1 = Component.translatable("skill.dragonminez.kiweapon." + weaponType).withStyle(ChatFormatting.BOLD);
-					line2 = Component.translatable("gui.action.dragonminez." + statsData.getSkills().isSkillActive("kimanipulation"));
-				}
-			}
-			case 6 -> {
-				if ("saiyan".equals(race)) {
-					line1 = Component.translatable("gui.action.dragonminez.tail").withStyle(ChatFormatting.BOLD);
-					line2 = Component.translatable("gui.action.dragonminez." + (statsData.getStatus().isTailVisible()));
-					isSelected = statsData.getStatus().isTailVisible();
-				} else if ("namekian".equals(race) || "bioandroid".equals(race) || "majin".equals(race)) {
-					line1 = Component.translatable("gui.action.dragonminez.racial." + race).withStyle(ChatFormatting.BOLD);
-					line2 = Component.translatable("gui.action.dragonminez." + (statsData.getStatus().getSelectedAction() == ActionMode.RACIAL ? "true" : "false"));
-					isSelected = currentMode == ActionMode.RACIAL;
-				}
-			}
-			case 7 -> {
-				if ("frostdemon".equals(race) || "majin".equals(race) || "bioandroid".equals(race)) {
-					line1 = Component.translatable("gui.action.dragonminez.descend").withStyle(ChatFormatting.BOLD);
-					line2 = Component.translatable("gui.action.dragonminez.revert_form");
-				}
-			}
-		}
-
-		if (isSelected) color = 0x2BFF00;
-
-		if (!line1.getString().isEmpty()) {
-			drawCenteredStringWithBorder(graphics, line1, x + BUTTON_WIDTH / 2, y + 12, 0xFFFFFF, 0x000000);
-			if (index == 5) graphics.drawCenteredString(font, line2, x + BUTTON_WIDTH / 2, y + 30, statsData.getSkills().isSkillActive("kimanipulation") ? 0x2BFF00 : 0xFF1B00);
-			else graphics.drawCenteredString(font, line2, x + BUTTON_WIDTH / 2, y + 30, isSelected ? color : 0xFF1B00);
 		}
 	}
 
@@ -188,77 +154,9 @@ public class UtilityMenuScreen extends Screen {
 	}
 
 	private void handleSlotClick(int index) {
-		String race = statsData.getCharacter().getRaceName();
-		Minecraft mc = Minecraft.getInstance();
-
-		switch (index) {
-			case 0 -> {
-				if (statsData.getSkills().hasSkill("kaioken")) {
-					boolean wasActive = statsData.getStatus().getSelectedAction() == ActionMode.KAIOKEN;
-					NetworkHandler.sendToServer(new SwitchActionC2S(ActionMode.KAIOKEN));
-					playToggleSound(mc, !wasActive);
-				}
-			}
-			case 1 -> {
-				if (statsData.getSkills().getSkillLevel("superform") >= 1 || statsData.getSkills().getSkillLevel("legendaryforms") >= 1 || statsData.getSkills().getSkillLevel("godform") >= 1 || statsData.getSkills().getSkillLevel("androidforms") >= 1) {
-					boolean wasActive = statsData.getStatus().getSelectedAction() == ActionMode.FORM;
-					if (wasActive && statsData.getCharacter().hasActiveForm()) {
-						if (TransformationsHelper.canDescend(statsData)) {
-							NetworkHandler.sendToServer(new ExecuteActionC2S("descend"));
-							playToggleSound(mc, false);
-						}
-					} else if (!wasActive) {
-						NetworkHandler.sendToServer(new SwitchActionC2S(ActionMode.FORM));
-						playToggleSound(mc, true);
-					} else {
-						NetworkHandler.sendToServer(new ExecuteActionC2S("cycle_form_group"));
-						playToggleSound(mc, true);
-					}
-				}
-			}
-			case 2 -> {
-				if (statsData.getSkills().hasSkill("fusion")) {
-					boolean wasActive = statsData.getStatus().getSelectedAction() == ActionMode.FUSION;
-					NetworkHandler.sendToServer(new SwitchActionC2S(ActionMode.FUSION));
-					playToggleSound(mc, !wasActive);
-				}
-			}
-			case 5 -> {
-				if (statsData.getSkills().hasSkill("kimanipulation") && statsData.getSkills().hasSkill("kicontrol")) {
-					boolean wasActive = statsData.getSkills().isSkillActive("kimanipulation");
-					NetworkHandler.sendToServer(new ExecuteActionC2S("toggle_ki_weapon"));
-					playToggleSound(mc, !wasActive);
-				}
-			}
-			case 6 -> {
-				if ("saiyan".equals(race)) {
-					boolean wasActive = statsData.getStatus().isTailVisible();
-					NetworkHandler.sendToServer(new ExecuteActionC2S("toggle_tail"));
-					playToggleSound(mc, !wasActive);
-				}
-				else if ("namekian".equals(race) || "bioandroid".equals(race) || "majin".equals(race)) {
-					boolean wasActive = statsData.getStatus().getSelectedAction() == ActionMode.RACIAL;
-					NetworkHandler.sendToServer(new SwitchActionC2S(ActionMode.RACIAL));
-					playToggleSound(mc, !wasActive);
-				}
-			}
-			case 7 -> {
-				if ("frostdemon".equals(race) || "majin".equals(race) || "bioandroid".equals(race)) {
-					NetworkHandler.sendToServer(new ExecuteActionC2S("force_descend"));
-					// Descender siempre es desactivar, entonces suena OFF
-					playToggleSound(mc, false);
-				}
-			}
-		}
-	}
-
-	private void playToggleSound(Minecraft mc, boolean turnedOn) {
-		if (mc.player != null) {
-			if (turnedOn) {
-				mc.player.playSound(MainSounds.SWITCH_ON.get(), 1.0F, 1.0F);
-			} else {
-				mc.player.playSound(MainSounds.SWITCH_OFF.get(), 1.0F, 1.0F);
-			}
+		IUtilityMenuSlot menuSlot = menuSlots.get(index);
+		if (menuSlot != null) {
+			menuSlot.handle(statsData);
 		}
 	}
 

--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/AbstractMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/AbstractMenuSlot.java
@@ -1,0 +1,17 @@
+package com.dragonminez.client.gui.utilitymenu;
+
+import com.dragonminez.common.init.MainSounds;
+import net.minecraft.client.Minecraft;
+
+public abstract class AbstractMenuSlot {
+    protected void playToggleSound(boolean turnedOn) {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.player != null) {
+            if (turnedOn) {
+                mc.player.playSound(MainSounds.SWITCH_ON.get(), 1.0F, 1.0F);
+            } else {
+                mc.player.playSound(MainSounds.SWITCH_OFF.get(), 1.0F, 1.0F);
+            }
+        }
+    }
+}

--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/ButtonInfo.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/ButtonInfo.java
@@ -1,0 +1,45 @@
+package com.dragonminez.client.gui.utilitymenu;
+
+import net.minecraft.network.chat.Component;
+
+public class ButtonInfo {
+    protected Component line1 = Component.empty();
+    protected Component line2 = Component.empty();
+    protected int color = 0xFFFFFF;
+    protected boolean isSelected = false;
+
+    public ButtonInfo() {
+        // Default empty constructor
+    }
+
+    public ButtonInfo(Component line1, Component line2) {
+        this.line1 = line1;
+        this.line2 = line2;
+    }
+
+    public ButtonInfo(Component line1, Component line2, boolean isSelected) {
+        this.line1 = line1;
+        this.line2 = line2;
+        this.isSelected = isSelected;
+    }
+
+    public Component getLine1() {
+        return line1;
+    }
+
+    public Component getLine2() {
+        return line2;
+    }
+
+    public int getColor() {
+        return color;
+    }
+
+    public boolean isSelected() {
+        return isSelected;
+    }
+
+    public void setColor(int color) {
+        this.color = color;
+    }
+}

--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/IUtilityMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/IUtilityMenuSlot.java
@@ -1,0 +1,8 @@
+package com.dragonminez.client.gui.utilitymenu;
+
+import com.dragonminez.common.stats.StatsData;
+
+public interface IUtilityMenuSlot {
+    ButtonInfo render(StatsData statsData);
+    void handle(StatsData statsData);
+}

--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/DescendFormMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/DescendFormMenuSlot.java
@@ -1,0 +1,38 @@
+package com.dragonminez.client.gui.utilitymenu.menuslots;
+
+import com.dragonminez.client.gui.utilitymenu.AbstractMenuSlot;
+import com.dragonminez.client.gui.utilitymenu.ButtonInfo;
+import com.dragonminez.client.gui.utilitymenu.IUtilityMenuSlot;
+import com.dragonminez.common.network.C2S.ExecuteActionC2S;
+import com.dragonminez.common.network.NetworkHandler;
+import com.dragonminez.common.stats.ActionMode;
+import com.dragonminez.common.stats.StatsData;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+
+public class DescendFormMenuSlot extends AbstractMenuSlot implements IUtilityMenuSlot {
+    @Override
+    public ButtonInfo render(StatsData statsData) {
+        ActionMode currentMode = statsData.getStatus().getSelectedAction();
+        String race = statsData.getCharacter().getRaceName();
+
+        if ("frostdemon".equals(race) || "majin".equals(race) || "bioandroid".equals(race)) {
+            return new ButtonInfo(
+                    Component.translatable("gui.action.dragonminez.descend").withStyle(ChatFormatting.BOLD),
+                    Component.translatable("gui.action.dragonminez.revert_form")
+            );
+        } else {
+            return new ButtonInfo();
+        }
+    }
+
+    @Override
+    public void handle(StatsData statsData) {
+        String race = statsData.getCharacter().getRaceName();
+        if ("frostdemon".equals(race) || "majin".equals(race) || "bioandroid".equals(race)) {
+            NetworkHandler.sendToServer(new ExecuteActionC2S("force_descend"));
+            // Descender siempre es desactivar, entonces suena OFF
+            playToggleSound(false);
+        }
+    }
+}

--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/EmptyMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/EmptyMenuSlot.java
@@ -1,0 +1,22 @@
+package com.dragonminez.client.gui.utilitymenu.menuslots;
+
+import com.dragonminez.client.gui.utilitymenu.AbstractMenuSlot;
+import com.dragonminez.client.gui.utilitymenu.ButtonInfo;
+import com.dragonminez.client.gui.utilitymenu.IUtilityMenuSlot;
+import com.dragonminez.common.network.C2S.ExecuteActionC2S;
+import com.dragonminez.common.network.NetworkHandler;
+import com.dragonminez.common.stats.ActionMode;
+import com.dragonminez.common.stats.StatsData;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+
+public class EmptyMenuSlot extends AbstractMenuSlot implements IUtilityMenuSlot {
+    @Override
+    public ButtonInfo render(StatsData statsData) {
+        return new ButtonInfo();
+    }
+
+    @Override
+    public void handle(StatsData statsData) {
+    }
+}

--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/FusionMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/FusionMenuSlot.java
@@ -1,0 +1,36 @@
+package com.dragonminez.client.gui.utilitymenu.menuslots;
+
+import com.dragonminez.client.gui.utilitymenu.AbstractMenuSlot;
+import com.dragonminez.client.gui.utilitymenu.ButtonInfo;
+import com.dragonminez.client.gui.utilitymenu.IUtilityMenuSlot;
+import com.dragonminez.common.network.C2S.SwitchActionC2S;
+import com.dragonminez.common.network.NetworkHandler;
+import com.dragonminez.common.stats.ActionMode;
+import com.dragonminez.common.stats.StatsData;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+
+public class FusionMenuSlot extends AbstractMenuSlot implements IUtilityMenuSlot {
+    @Override
+    public ButtonInfo render(StatsData statsData) {
+        ActionMode currentMode = statsData.getStatus().getSelectedAction();
+
+        if (statsData.getSkills().hasSkill("fusion")) {
+            return new ButtonInfo(
+                    Component.translatable("gui.action.dragonminez.fusion").withStyle(ChatFormatting.BOLD),
+                    Component.translatable("gui.action.dragonminez." + (statsData.getStatus().getSelectedAction() == ActionMode.FUSION ? "true" : "false")),
+                    currentMode == ActionMode.FUSION);
+        } else {
+            return new ButtonInfo();
+        }
+    }
+
+    @Override
+    public void handle(StatsData statsData) {
+        if (statsData.getSkills().hasSkill("fusion")) {
+            boolean wasActive = statsData.getStatus().getSelectedAction() == ActionMode.FUSION;
+            NetworkHandler.sendToServer(new SwitchActionC2S(ActionMode.FUSION));
+            playToggleSound(!wasActive);
+        }
+    }
+}

--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/KaiokenMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/KaiokenMenuSlot.java
@@ -1,0 +1,36 @@
+package com.dragonminez.client.gui.utilitymenu.menuslots;
+
+import com.dragonminez.client.gui.utilitymenu.AbstractMenuSlot;
+import com.dragonminez.client.gui.utilitymenu.ButtonInfo;
+import com.dragonminez.client.gui.utilitymenu.IUtilityMenuSlot;
+import com.dragonminez.common.network.C2S.SwitchActionC2S;
+import com.dragonminez.common.network.NetworkHandler;
+import com.dragonminez.common.stats.ActionMode;
+import com.dragonminez.common.stats.StatsData;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+
+public class KaiokenMenuSlot extends AbstractMenuSlot implements IUtilityMenuSlot {
+    @Override
+    public ButtonInfo render(StatsData statsData) {
+        ActionMode currentMode = statsData.getStatus().getSelectedAction();
+
+        if (statsData.getSkills().hasSkill("kaioken")) {
+            return new ButtonInfo(
+                    Component.translatable("gui.action.dragonminez.kaioken").withStyle(ChatFormatting.BOLD),
+                    Component.translatable("gui.action.dragonminez." + (statsData.getStatus().getSelectedAction() == ActionMode.KAIOKEN ? "true" : "false")),
+                    currentMode == ActionMode.KAIOKEN);
+        } else {
+            return new ButtonInfo();
+        }
+    }
+
+    @Override
+    public void handle(StatsData statsData) {
+        if (statsData.getSkills().hasSkill("kaioken")) {
+            boolean wasActive = statsData.getStatus().getSelectedAction() == ActionMode.KAIOKEN;
+            NetworkHandler.sendToServer(new SwitchActionC2S(ActionMode.KAIOKEN));
+            playToggleSound(!wasActive);
+        }
+    }
+}

--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/KiManipulationMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/KiManipulationMenuSlot.java
@@ -1,0 +1,33 @@
+package com.dragonminez.client.gui.utilitymenu.menuslots;
+
+import com.dragonminez.client.gui.utilitymenu.AbstractMenuSlot;
+import com.dragonminez.client.gui.utilitymenu.ButtonInfo;
+import com.dragonminez.client.gui.utilitymenu.IUtilityMenuSlot;
+import com.dragonminez.common.network.C2S.ExecuteActionC2S;
+import com.dragonminez.common.network.NetworkHandler;
+import com.dragonminez.common.stats.StatsData;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+
+public class KiManipulationMenuSlot extends AbstractMenuSlot implements IUtilityMenuSlot {
+    @Override
+    public ButtonInfo render(StatsData statsData) {
+        if (statsData.getSkills().hasSkill("kimanipulation") && statsData.getSkills().hasSkill("kicontrol")) {
+            String weaponType = statsData.getStatus().getKiWeaponType();
+            return new ButtonInfo(
+                    Component.translatable("skill.dragonminez.kiweapon." + weaponType).withStyle(ChatFormatting.BOLD),
+                    Component.translatable("gui.action.dragonminez." + statsData.getSkills().isSkillActive("kimanipulation")));
+        } else {
+            return new ButtonInfo();
+        }
+    }
+
+    @Override
+    public void handle(StatsData statsData) {
+        if (statsData.getSkills().hasSkill("kimanipulation") && statsData.getSkills().hasSkill("kicontrol")) {
+            boolean wasActive = statsData.getSkills().isSkillActive("kimanipulation");
+            NetworkHandler.sendToServer(new ExecuteActionC2S("toggle_ki_weapon"));
+            playToggleSound(!wasActive);
+        }
+    }
+}

--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/RacialActionMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/RacialActionMenuSlot.java
@@ -1,0 +1,51 @@
+package com.dragonminez.client.gui.utilitymenu.menuslots;
+
+import com.dragonminez.client.gui.utilitymenu.AbstractMenuSlot;
+import com.dragonminez.client.gui.utilitymenu.ButtonInfo;
+import com.dragonminez.client.gui.utilitymenu.IUtilityMenuSlot;
+import com.dragonminez.common.network.C2S.ExecuteActionC2S;
+import com.dragonminez.common.network.C2S.SwitchActionC2S;
+import com.dragonminez.common.network.NetworkHandler;
+import com.dragonminez.common.stats.ActionMode;
+import com.dragonminez.common.stats.StatsData;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+
+public class RacialActionMenuSlot extends AbstractMenuSlot implements IUtilityMenuSlot {
+    @Override
+    public ButtonInfo render(StatsData statsData) {
+        ActionMode currentMode = statsData.getStatus().getSelectedAction();
+        String race = statsData.getCharacter().getRaceName();
+
+        if ("saiyan".equals(race)) {
+            return new ButtonInfo(
+                    Component.translatable("gui.action.dragonminez.tail").withStyle(ChatFormatting.BOLD),
+                    Component.translatable("gui.action.dragonminez." + (statsData.getStatus().isTailVisible())),
+                    statsData.getStatus().isTailVisible()
+            );
+        } else if ("namekian".equals(race) || "bioandroid".equals(race) || "majin".equals(race)) {
+            return new ButtonInfo(
+                    Component.translatable("gui.action.dragonminez.racial." + race).withStyle(ChatFormatting.BOLD),
+                    Component.translatable("gui.action.dragonminez." + (statsData.getStatus().getSelectedAction() == ActionMode.RACIAL ? "true" : "false")),
+                    currentMode == ActionMode.RACIAL
+            );
+        } else {
+            return new ButtonInfo();
+        }
+    }
+
+    @Override
+    public void handle(StatsData statsData) {
+        String race = statsData.getCharacter().getRaceName();
+        if ("saiyan".equals(race)) {
+            boolean wasActive = statsData.getStatus().isTailVisible();
+            NetworkHandler.sendToServer(new ExecuteActionC2S("toggle_tail"));
+            playToggleSound(!wasActive);
+        }
+        else if ("namekian".equals(race) || "bioandroid".equals(race) || "majin".equals(race)) {
+            boolean wasActive = statsData.getStatus().getSelectedAction() == ActionMode.RACIAL;
+            NetworkHandler.sendToServer(new SwitchActionC2S(ActionMode.RACIAL));
+            playToggleSound(!wasActive);
+        }
+    }
+}

--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/SuperformMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/SuperformMenuSlot.java
@@ -1,0 +1,49 @@
+package com.dragonminez.client.gui.utilitymenu.menuslots;
+
+import com.dragonminez.client.gui.utilitymenu.AbstractMenuSlot;
+import com.dragonminez.client.gui.utilitymenu.ButtonInfo;
+import com.dragonminez.client.gui.utilitymenu.IUtilityMenuSlot;
+import com.dragonminez.common.network.C2S.ExecuteActionC2S;
+import com.dragonminez.common.network.C2S.SwitchActionC2S;
+import com.dragonminez.common.network.NetworkHandler;
+import com.dragonminez.common.stats.ActionMode;
+import com.dragonminez.common.stats.StatsData;
+import com.dragonminez.common.util.TransformationsHelper;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+
+public class SuperformMenuSlot extends AbstractMenuSlot implements IUtilityMenuSlot {
+    @Override
+    public ButtonInfo render(StatsData statsData) {
+        ActionMode currentMode = statsData.getStatus().getSelectedAction();
+        String race = statsData.getCharacter().getRaceName();
+
+        if (statsData.getSkills().getSkillLevel("superform") >= 1 || statsData.getSkills().getSkillLevel("legendaryforms") >= 1 || statsData.getSkills().getSkillLevel("godform") >= 1 || statsData.getSkills().getSkillLevel("androidforms") >= 1) {
+            return new ButtonInfo(
+                    Component.translatable("race.dragonminez." + race + ".group." + statsData.getCharacter().getSelectedFormGroup()).withStyle(ChatFormatting.BOLD),
+                    Component.translatable("race.dragonminez." + race + ".form." + statsData.getCharacter().getSelectedFormGroup() + "." + TransformationsHelper.getFirstFormGroup(statsData.getCharacter().getSelectedFormGroup(), race)),
+                    currentMode == ActionMode.FORM);
+        } else {
+            return new ButtonInfo();
+        }
+    }
+
+    @Override
+    public void handle(StatsData statsData) {
+        if (statsData.getSkills().getSkillLevel("superform") >= 1 || statsData.getSkills().getSkillLevel("legendaryforms") >= 1 || statsData.getSkills().getSkillLevel("godform") >= 1 || statsData.getSkills().getSkillLevel("androidforms") >= 1) {
+            boolean wasActive = statsData.getStatus().getSelectedAction() == ActionMode.FORM;
+            if (wasActive && statsData.getCharacter().hasActiveForm()) {
+                if (TransformationsHelper.canDescend(statsData)) {
+                    NetworkHandler.sendToServer(new ExecuteActionC2S("descend"));
+                    playToggleSound(false);
+                }
+            } else if (!wasActive) {
+                NetworkHandler.sendToServer(new SwitchActionC2S(ActionMode.FORM));
+                playToggleSound(true);
+            } else {
+                NetworkHandler.sendToServer(new ExecuteActionC2S("cycle_form_group"));
+                playToggleSound(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resized the Utility Menu to be a 3x5 grid and refactored the grid initialization to be self contained and avoid duplicate entries.
Made the grid rendering dynamic by not depending on fixed sizes for the grid. We can now define whatever sized grid we want and use that.
Each menu slot implements a render and handle method call, this makes it so no button handling is ever hardcoded.