### PR TITLE
WishManager rewrite

### DIFF
--- a/src/main/java/com/dragonminez/common/wish/CommandWish.java
+++ b/src/main/java/com/dragonminez/common/wish/CommandWish.java
@@ -1,14 +1,13 @@
 package com.dragonminez.common.wish;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
+import com.google.gson.GsonBuilder;
 import net.minecraft.server.level.ServerPlayer;
 
 public class CommandWish extends Wish {
     private final String[] commands;
 
     public CommandWish(String name, String description, String... commands) {
-        super(name, description);
+        super(name, description, "command");
         this.commands = commands;
     }
 
@@ -21,16 +20,7 @@ public class CommandWish extends Wish {
     }
 
     @Override
-    public JsonObject toJson() {
-        JsonObject json = new JsonObject();
-        json.addProperty("type", "command");
-        json.addProperty("name", getName());
-        json.addProperty("description", getDescription());
-        JsonArray commandsArray = new JsonArray();
-        for (String command : commands) {
-            commandsArray.add(command);
-        }
-        json.add("commands", commandsArray);
-        return json;
+    public String toJson() {
+        return new GsonBuilder().setPrettyPrinting().create().toJson(this, CommandWish.class);
     }
 }

--- a/src/main/java/com/dragonminez/common/wish/ItemWish.java
+++ b/src/main/java/com/dragonminez/common/wish/ItemWish.java
@@ -2,7 +2,7 @@ package com.dragonminez.common.wish;
 
 import com.dragonminez.Env;
 import com.dragonminez.LogUtil;
-import com.google.gson.JsonObject;
+import com.google.gson.GsonBuilder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.Item;
@@ -14,7 +14,7 @@ public class ItemWish extends Wish {
     private final int count;
 
     public ItemWish(String name, String description, String itemId, int count) {
-        super(name, description);
+        super(name, description, "item");
         this.itemId = itemId;
         this.count = count;
     }
@@ -30,13 +30,7 @@ public class ItemWish extends Wish {
     }
 
     @Override
-    public JsonObject toJson() {
-        JsonObject json = new JsonObject();
-        json.addProperty("type", "item");
-        json.addProperty("name", getName());
-        json.addProperty("description", getDescription());
-        json.addProperty("item_id", itemId);
-        json.addProperty("count", count);
-        return json;
+    public String toJson() {
+        return new GsonBuilder().setPrettyPrinting().create().toJson(this, ItemWish.class);
     }
 }

--- a/src/main/java/com/dragonminez/common/wish/MultiItemWish.java
+++ b/src/main/java/com/dragonminez/common/wish/MultiItemWish.java
@@ -1,0 +1,39 @@
+package com.dragonminez.common.wish;
+
+import com.dragonminez.Env;
+import com.dragonminez.LogUtil;
+import com.google.gson.GsonBuilder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Tuple;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.List;
+
+public class MultiItemWish extends Wish {
+    private final List<Tuple<String, Integer>> items;
+
+    public MultiItemWish(String name, String description, List<Tuple<String, Integer>> items) {
+        super(name, description, "multi_wish");
+        this.items = items;
+    }
+
+    @Override
+    public void grant(ServerPlayer player) {
+        for (Tuple<String, Integer> itemInfo : items) {
+            Item item = ForgeRegistries.ITEMS.getValue(ResourceLocation.parse(itemInfo.getA()));
+            if (item != null) {
+                player.getInventory().add(new ItemStack(item, itemInfo.getB()));
+            } else {
+                LogUtil.warn(Env.COMMON, "Item with id " + itemInfo.getA() + " not found.");
+            }
+        }
+    }
+
+    @Override
+    public String toJson() {
+        return new GsonBuilder().setPrettyPrinting().create().toJson(this, MultiItemWish.class);
+    }
+}

--- a/src/main/java/com/dragonminez/common/wish/TPSWish.java
+++ b/src/main/java/com/dragonminez/common/wish/TPSWish.java
@@ -2,31 +2,24 @@ package com.dragonminez.common.wish;
 
 import com.dragonminez.common.stats.StatsCapability;
 import com.dragonminez.common.stats.StatsProvider;
-import com.google.gson.JsonObject;
+import com.google.gson.GsonBuilder;
 import net.minecraft.server.level.ServerPlayer;
 
 public class TPSWish extends Wish {
     private final int amount;
 
     public TPSWish(String name, String description, int amount) {
-        super(name, description);
+        super(name, description, "tps");
         this.amount = amount;
     }
 
     @Override
     public void grant(ServerPlayer player) {
-        StatsProvider.get(StatsCapability.INSTANCE, player).ifPresent(data -> {
-            data.getResources().addTrainingPoints(amount);
-        });
+        StatsProvider.get(StatsCapability.INSTANCE, player).ifPresent(data -> data.getResources().addTrainingPoints(amount));
     }
 
     @Override
-    public JsonObject toJson() {
-        JsonObject json = new JsonObject();
-        json.addProperty("type", "tps");
-        json.addProperty("name", getName());
-        json.addProperty("description", getDescription());
-        json.addProperty("amount", amount);
-        return json;
+    public String toJson() {
+        return new GsonBuilder().setPrettyPrinting().create().toJson(this, TPSWish.class);
     }
 }

--- a/src/main/java/com/dragonminez/common/wish/Wish.java
+++ b/src/main/java/com/dragonminez/common/wish/Wish.java
@@ -1,15 +1,16 @@
 package com.dragonminez.common.wish;
 
-import com.google.gson.JsonObject;
 import net.minecraft.server.level.ServerPlayer;
 
 public abstract class Wish {
     private final String name;
     private final String description;
+    private final String type;
 
-    public Wish(String name, String description) {
+    public Wish(String name, String description, String type) {
         this.name = name;
         this.description = description;
+        this.type = type;
     }
 
     public String getName() {
@@ -20,7 +21,11 @@ public abstract class Wish {
         return description;
     }
 
+    public String getType() {
+        return type;
+    }
+
     public abstract void grant(ServerPlayer player);
 
-    public abstract JsonObject toJson();
+    public abstract String toJson();
 }


### PR DESCRIPTION
Refactored WishManager to allow for wishes rewarding multiple items at once.

This removes the need for commands for things like Potala and Armor Sets, for example, thus allowing those wishes to work on worlds with cheats disabled.