### PR TITLE
Make tpMultiplier static

### DIFF
--- a/src/main/java/com/dragonminez/client/gui/character/CharacterStatsScreen.java
+++ b/src/main/java/com/dragonminez/client/gui/character/CharacterStatsScreen.java
@@ -43,10 +43,10 @@ public class CharacterStatsScreen extends BaseMenuScreen {
             "textures/gui/menu/menusmall.png");
     private static final ResourceLocation BUTTONS_TEXTURE = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
             "textures/gui/buttons/characterbuttons.png");
+    private static int tpMultiplier = 1;
 
     private StatsData statsData;
     private int tickCount = 0;
-    private int tpMultiplier = 1;
     private final NumberFormat numberFormatter = NumberFormat.getInstance(Locale.US);
     private boolean useHexagonView = false;
 


### PR DESCRIPTION
Changed stat point allocation multiplier (tpMultiplier) to be static, thus not being reset when closing and reopening the stats menu.