### PR TITLE
If no form or form group is selected, display no info.

### DIFF
--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/StackFormMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/StackFormMenuSlot.java
@@ -17,13 +17,22 @@ public class StackFormMenuSlot extends AbstractMenuSlot implements IUtilityMenuS
     public ButtonInfo render(StatsData statsData) {
         ActionMode currentMode = statsData.getStatus().getSelectedAction();
 
+        // FIXME: The first time a Stack Form Group is unlocked, no Stack Form Group is selected
+        //  so the button will always be empty unless players click it after.
         if (statsData.getSkills().getSkillLevel("kaioken") >= 1
                 || statsData.getSkills().getSkillLevel("ultrainstinct") >= 1
                 || statsData.getSkills().getSkillLevel("ultraego") >= 1) {
-            return new ButtonInfo(
-                    Component.translatable("race.dragonminez.stack.group." + statsData.getCharacter().getSelectedStackFormGroup()).withStyle(ChatFormatting.BOLD),
-                    Component.translatable("race.dragonminez.stack.form." + statsData.getCharacter().getSelectedStackFormGroup() + "." + TransformationsHelper.getFirstStackFormGroup(statsData.getCharacter().getSelectedStackFormGroup())),
-                    currentMode == ActionMode.STACK);
+            String selectedStackFormGroup = statsData.getCharacter().getSelectedStackFormGroup();
+            String firstStackFormGroup = TransformationsHelper.getFirstStackFormGroup(selectedStackFormGroup);
+            if (selectedStackFormGroup != null && !selectedStackFormGroup.isEmpty()
+                    && firstStackFormGroup != null && !firstStackFormGroup.isEmpty()) {
+                return new ButtonInfo(
+                        Component.translatable("race.dragonminez.stack.group." + selectedStackFormGroup).withStyle(ChatFormatting.BOLD),
+                        Component.translatable("race.dragonminez.stack.form." + selectedStackFormGroup + "." + firstStackFormGroup),
+                        currentMode == ActionMode.STACK);
+            } else {
+                return new ButtonInfo();
+            }
         } else {
             return new ButtonInfo();
         }

--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/SuperformMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/SuperformMenuSlot.java
@@ -19,10 +19,17 @@ public class SuperformMenuSlot extends AbstractMenuSlot implements IUtilityMenuS
         String race = statsData.getCharacter().getRaceName();
 
         if (statsData.getSkills().getSkillLevel("superform") >= 1 || statsData.getSkills().getSkillLevel("legendaryforms") >= 1 || statsData.getSkills().getSkillLevel("godform") >= 1 || statsData.getSkills().getSkillLevel("androidforms") >= 1) {
-            return new ButtonInfo(
-                    Component.translatable("race.dragonminez." + race + ".group." + statsData.getCharacter().getSelectedFormGroup()).withStyle(ChatFormatting.BOLD),
-                    Component.translatable("race.dragonminez." + race + ".form." + statsData.getCharacter().getSelectedFormGroup() + "." + TransformationsHelper.getFirstFormGroup(statsData.getCharacter().getSelectedFormGroup(), race)),
-                    currentMode == ActionMode.FORM);
+            String selectedFormGroup = statsData.getCharacter().getSelectedFormGroup();
+            String firstFormGroup = TransformationsHelper.getFirstFormGroup(selectedFormGroup, race);
+            if (selectedFormGroup != null && !selectedFormGroup.isEmpty()
+                    && firstFormGroup != null && !firstFormGroup.isEmpty()) {
+                return new ButtonInfo(
+                        Component.translatable("race.dragonminez." + race + ".group." + statsData.getCharacter().getSelectedFormGroup()).withStyle(ChatFormatting.BOLD),
+                        Component.translatable("race.dragonminez." + race + ".form." + statsData.getCharacter().getSelectedFormGroup() + "." + TransformationsHelper.getFirstFormGroup(statsData.getCharacter().getSelectedFormGroup(), race)),
+                        currentMode == ActionMode.FORM);
+            } else {
+                return new ButtonInfo();
+            }
         } else {
             return new ButtonInfo();
         }


### PR DESCRIPTION
This fixes things like the following screenshot but lacks handling for the first Stack Form group the player unlocks so the button won't display anything till clicked the first time after unlocking a Stack Form :/
<img width="1887" height="1078" alt="image" src="https://github.com/user-attachments/assets/4ef2cde3-75d9-4d94-aa3e-73cffcd5660e" />
