### PR TITLE
Adds a command to change whether a Saiyan character has a tail or not.

### DIFF
--- a/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/RacialActionMenuSlot.java
+++ b/src/main/java/com/dragonminez/client/gui/utilitymenu/menuslots/RacialActionMenuSlot.java
@@ -17,9 +17,10 @@ public class RacialActionMenuSlot extends AbstractMenuSlot implements IUtilityMe
     public ButtonInfo render(StatsData statsData) {
         ActionMode currentMode = statsData.getStatus().getSelectedAction();
         String race = statsData.getCharacter().getRaceName();
+        String form = statsData.getCharacter().getActiveForm();
         String racialSkill = ConfigManager.getRaceCharacter(race) == null ? "" : ConfigManager.getRaceCharacter(race).getRacialSkill();
 
-        if ("saiyan".equals(race)) {
+        if ("saiyan".equals(race) && (statsData.getCharacter().hasSaiyanTail() || (form != null && form.contains("oozaru")))) {
             return new ButtonInfo(
                     Component.translatable("gui.action.dragonminez.tail").withStyle(ChatFormatting.BOLD),
                     Component.translatable("gui.action.dragonminez." + (statsData.getStatus().isTailVisible())),

--- a/src/main/java/com/dragonminez/client/render/layer/DMZRacePartsLayer.java
+++ b/src/main/java/com/dragonminez/client/render/layer/DMZRacePartsLayer.java
@@ -174,7 +174,7 @@ public class DMZRacePartsLayer<T extends AbstractClientPlayer & GeoAnimatable> e
         boolean isSaiyanLogic = logicKey.equals("saiyan") || logicKey.equals("saiyan_ssj4") || race.equals("saiyan");
         boolean isOozaru = logicKey.equals("oozaru") || currentForm.contains("oozaru");
 
-        if (isSaiyanLogic && !stats.getStatus().isTailVisible() && !isOozaru) {
+        if (isSaiyanLogic && !stats.getStatus().isTailVisible() && !isOozaru && character.hasSaiyanTail()) {
             setupSaiyanParts(partsModel);
 
             return (hasForm || hasStackForm || stats.getStatus().isActionCharging())

--- a/src/main/java/com/dragonminez/client/render/layer/DMZSkinLayer.java
+++ b/src/main/java/com/dragonminez/client/render/layer/DMZSkinLayer.java
@@ -1,7 +1,5 @@
 package com.dragonminez.client.render.layer;
 
-import com.dragonminez.Env;
-import com.dragonminez.LogUtil;
 import com.dragonminez.Reference;
 import com.dragonminez.client.util.ColorUtils;
 import com.dragonminez.common.config.ConfigManager;
@@ -129,7 +127,7 @@ public class DMZSkinLayer<T extends AbstractClientPlayer & GeoAnimatable> extend
         }
 
         boolean isSaiyanLogic = logicKey.equals("saiyan") || logicKey.equals("saiyan_ssj4") || raceName.equals("saiyan");
-        if (isSaiyanLogic && stats.getStatus().isTailVisible()) {
+        if (isSaiyanLogic && stats.getStatus().isTailVisible() && character.hasSaiyanTail()) {
             boolean hasActiveForm = character.hasActiveForm();
             boolean hasActiveStackForm = character.hasActiveStackForm();
             float[] tailColor;

--- a/src/main/java/com/dragonminez/common/network/C2S/NPCActionC2S.java
+++ b/src/main/java/com/dragonminez/common/network/C2S/NPCActionC2S.java
@@ -115,6 +115,7 @@ public class NPCActionC2S {
 			data.getBonusStats().clearAllStats();
 			data.getCharacter().clearActiveForm();
 			data.getCharacter().clearActiveStackForm();
+			data.getCharacter().setSaiyanTail(true);
 			data.getStatus().setCreatedCharacter(false);
 
 			player.refreshDimensions();

--- a/src/main/java/com/dragonminez/common/stats/Character.java
+++ b/src/main/java/com/dragonminez/common/stats/Character.java
@@ -7,7 +7,6 @@ import com.dragonminez.common.hair.CustomHair;
 import com.dragonminez.common.hair.HairManager;
 import net.minecraft.nbt.CompoundTag;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class Character {
@@ -28,6 +27,8 @@ public class Character {
     private String activeStackForm = "";
     private final FormMasteries stackFormMasteries = new FormMasteries();
 	private UsedForms stackFormsUsedBefore = new UsedForms();
+
+	private boolean hasSaiyanTail = true;
 
     public static final String GENDER_MALE = "male";
     public static final String GENDER_FEMALE = "female";
@@ -152,6 +153,9 @@ public class Character {
 	public UsedForms getStackFormsUsedBefore() {
 		return stackFormsUsedBefore;
 	}
+	public boolean hasSaiyanTail() {
+		return hasSaiyanTail;
+	}
 	public Boolean getArmored() {return armored;}
 
 	public void setRace(String race) {
@@ -189,6 +193,9 @@ public class Character {
 	public void setSelectedStackFormGroup(String selectedStackFormGroup) { this.selectedStackFormGroup = selectedStackFormGroup; }
 	public void setSelectedStackForm(String selectedStackForm) {
 		this.selectedStackForm = selectedStackForm;
+	}
+	public void setSaiyanTail(boolean hasSaiyanTail) {
+		this.hasSaiyanTail = hasSaiyanTail;
 	}
 	public void setArmored(Boolean armored) {this.armored = armored;}
 
@@ -241,6 +248,7 @@ public class Character {
         tag.put("StackFormMasteries", stackFormMasteries.save());
 		tag.put("FormsUsedBefore", formsUsedBefore.save());
 		tag.put("StackFormsUsedBefore", stackFormsUsedBefore.save());
+		tag.putBoolean("HasSaiyanTail", hasSaiyanTail);
         tag.putBoolean("isArmored", armored);
         return tag;
     }
@@ -286,6 +294,7 @@ public class Character {
         this.activeStackForm = tag.getString("CurrentStackForm");
         if (tag.contains("StackFormMasteries")) stackFormMasteries.load(tag.getCompound("StackFormMasteries"));
 		if (tag.contains("StackFormsUsedBefore")) stackFormsUsedBefore.load(tag.getCompound("StackFormsUsedBefore"));
+		this.hasSaiyanTail = tag.getBoolean("HasSaiyanTail");
         this.armored = tag.getBoolean("isArmored");
     }
 
@@ -302,6 +311,11 @@ public class Character {
         this.activeFormGroup = "";
         this.activeForm = "";
     }
+
+	public void clearSelectedForm() {
+		this.selectedFormGroup = "";
+		this.selectedForm = "";
+	}
 
     public FormConfig.FormData getActiveFormData() {
         if (!hasActiveForm()) return null;

--- a/src/main/java/com/dragonminez/server/DMZServer.java
+++ b/src/main/java/com/dragonminez/server/DMZServer.java
@@ -14,6 +14,7 @@ public class DMZServer {
 
 	public static void registerCommands(CommandDispatcher<CommandSourceStack> dispatcher) {
 		StatsCommand.register(dispatcher);
+		SaiyanTailCommand.register(dispatcher);
 		BonusCommand.register(dispatcher);
 		EffectsCommand.register(dispatcher);
 		SkillsCommand.register(dispatcher);

--- a/src/main/java/com/dragonminez/server/commands/DMZPermissions.java
+++ b/src/main/java/com/dragonminez/server/commands/DMZPermissions.java
@@ -105,6 +105,9 @@ public class DMZPermissions {
     public static final PermissionNode<Boolean> FORMS_LIST_SELF = register("dmzform.list.self", "Allows listing your own forms.", (player, uuid, context) -> true);
     public static final PermissionNode<Boolean> FORMS_LIST_OTHERS = register("dmzform.list.others", "Allows listing other players' forms.", (player, uuid, context) -> false);
 
+    public static final PermissionNode<Boolean> SAIYAN_TAIL_SELF = register("dmzsaiyantail.set.self", "Allows setting your own saiyan tail.", (player, uuid, context) -> false);
+    public static final PermissionNode<Boolean> SAIYAN_TAIL_OTHERS = register("dmzsaiyantail.set.others", "Allows setting other players' saiyan tail.", (player, uuid, context) -> false);
+
     public static void init() {}
 
     private static PermissionNode<Boolean> register(String node, String description, PermissionNode.PermissionResolver<Boolean> defaultResolver) {

--- a/src/main/java/com/dragonminez/server/commands/SaiyanTailCommand.java
+++ b/src/main/java/com/dragonminez/server/commands/SaiyanTailCommand.java
@@ -1,0 +1,51 @@
+package com.dragonminez.server.commands;
+
+import com.dragonminez.common.config.ConfigManager;
+import com.dragonminez.common.network.NetworkHandler;
+import com.dragonminez.common.network.S2C.StatsSyncS2C;
+import com.dragonminez.common.stats.StatsCapability;
+import com.dragonminez.common.stats.StatsProvider;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Collection;
+import java.util.List;
+
+public class SaiyanTailCommand {
+
+	public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+		dispatcher.register(Commands.literal("dmzsaiyantail")
+				.requires(source -> DMZPermissions.check(source, DMZPermissions.SAIYAN_TAIL_SELF, DMZPermissions.SAIYAN_TAIL_OTHERS))
+
+				// set <amount> [targets]
+				.then(Commands.literal("set")
+						.then(Commands.argument("exists", BoolArgumentType.bool())
+								.executes(ctx -> setSaiyanTail(ctx.getSource(), List.of(ctx.getSource().getPlayerOrException()), BoolArgumentType.getBool(ctx, "exists")))
+								.then(Commands.argument("targets", EntityArgument.players())
+										.requires(source -> DMZPermissions.hasPermission(source, DMZPermissions.SAIYAN_TAIL_OTHERS))
+										.executes(ctx -> setSaiyanTail(ctx.getSource(), EntityArgument.getPlayers(ctx, "targets"), BoolArgumentType.getBool(ctx, "exists"))))))
+		);
+	}
+
+	private static int setSaiyanTail(CommandSourceStack source, Collection<ServerPlayer> targets, boolean exists) {
+		boolean log = ConfigManager.getServerConfig().getGameplay().isCommandOutputOnConsole();
+		for (ServerPlayer player : targets) {
+			StatsProvider.get(StatsCapability.INSTANCE, player).ifPresent(data -> {
+				data.getCharacter().setSaiyanTail(exists);
+				data.getCharacter().clearSelectedForm();
+				NetworkHandler.sendToTrackingEntityAndSelf(new StatsSyncS2C(player), player);
+			});
+		}
+		if (targets.size() == 1) {
+			source.sendSuccess(() -> Component.translatable("command.dragonminez.saiyantail.set.success", exists, targets.iterator().next().getName().getString()), log);
+		} else {
+			source.sendSuccess(() -> Component.translatable("command.dragonminez.saiyantail.set.multiple", exists, targets.size()), log);
+		}
+		return targets.size();
+	}
+}

--- a/src/main/java/com/dragonminez/server/events/players/TickHandler.java
+++ b/src/main/java/com/dragonminez/server/events/players/TickHandler.java
@@ -7,7 +7,6 @@ import com.dragonminez.common.config.RaceStatsConfig;
 import com.dragonminez.common.events.DMZEvent;
 import com.dragonminez.common.init.MainEffects;
 import com.dragonminez.common.init.MainItems;
-import com.dragonminez.common.network.C2S.ExecuteActionC2S;
 import com.dragonminez.common.network.NetworkHandler;
 import com.dragonminez.common.network.S2C.StatsSyncS2C;
 import com.dragonminez.common.stats.*;
@@ -406,6 +405,12 @@ public class TickHandler {
 	private static void handleActiveFormDrains(ServerPlayer player, StatsData data) {
 		boolean hasActiveForm = data.getCharacter().getActiveForm() != null && !data.getCharacter().getActiveForm().isEmpty();
 		boolean hasActiveStackForm = data.getCharacter().getActiveStackForm() != null && !data.getCharacter().getActiveStackForm().isEmpty();
+		if (hasActiveForm && data.getCharacter().getSelectedFormGroup().contains("oozaru") && !data.getCharacter().hasSaiyanTail()) {
+			data.getCharacter().clearActiveForm();
+			player.removeEffect(MainEffects.TRANSFORMED.get());
+			player.refreshDimensions();
+		}
+
 		if ((hasActiveForm || hasActiveStackForm) && !player.isCreative() && !player.isSpectator()) {
 			int energyDrain = (int) Math.round(data.getAdjustedEnergyDrain());
 			int staminaDrain = (int) Math.round(data.getAdjustedStaminaDrain());
@@ -428,7 +433,9 @@ public class TickHandler {
 				}
 			} else {
 				data.getCharacter().clearActiveStackForm();
+				player.removeEffect(MainEffects.STACK_TRANSFORMED.get());
 				data.getCharacter().clearActiveForm();
+				player.removeEffect(MainEffects.TRANSFORMED.get());
 				player.refreshDimensions();
 			}
 		}

--- a/src/main/resources/assets/dragonminez/lang/en_us.json
+++ b/src/main/resources/assets/dragonminez/lang/en_us.json
@@ -922,6 +922,8 @@
   "command.dragonminez.points.add.multiple": "§e[DMZ-Points]§r Added %s Training Points to %d players.",
   "command.dragonminez.points.remove.success": "§e[DMZ-Points]§r Removed %s Training Points from %s",
   "command.dragonminez.points.remove.multiple": "§e[DMZ-Points]§r Removed %s Training Points from %d players.",
+  "command.dragonminez.saiyantail.set.success": "§e[DMZ-SaiyanTail]§r Saiyan Tail set to %s for %s",
+  "command.dragonminez.saiyantail.set.multiple": "§e[DMZ-SaiyanTail]§r Saiyan Tail set to %s for %d players.",
   "command.dragonminez.bonus.add.success": "§e[DMZ-Bonus]§r Added bonus '%s' to %s for %s",
   "command.dragonminez.bonus.add.multiple": "§e[DMZ-Bonus]§r Added bonus '%s' to %d players for %s",
   "command.dragonminez.revive.success.self": "§e[DMZ-Revive]§r You have been revived!",


### PR DESCRIPTION
Tails will only render on the player model if the player is transformed into the Oozaru model or if the player still has his/her saiyan tail.

Saiyans without a tail lose access to the Oozaru form group and the tail mode button.

Resetting your character at Dende will reset your tail as well.

If a player is transformed into an Oozaru when the tail is cut, the player will revert to base form.