### PR TITLE
Aura del Kaioken

### DIFF
--- a/src/main/java/com/dragonminez/client/events/AuraRenderHandler.java
+++ b/src/main/java/com/dragonminez/client/events/AuraRenderHandler.java
@@ -46,19 +46,30 @@ import java.util.*;
 
 @Mod.EventBusSubscriber(modid = Reference.MOD_ID, value = Dist.CLIENT)
 public class AuraRenderHandler {
-	private static final ResourceLocation AURA_MODEL = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "geo/entity/races/kiaura.geo.json");
-	private static final ResourceLocation AURA_TEX_0 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "textures/entity/ki/aura_ki_0.png");
-	private static final ResourceLocation AURA_TEX_1 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "textures/entity/ki/aura_ki_1.png");
-	private static final ResourceLocation AURA_TEX_2 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "textures/entity/ki/aura_ki_2.png");
-	private static final ResourceLocation AURA_SLOW_MODEL = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "geo/entity/races/kiaura2.geo.json");
+	private static final ResourceLocation AURA_MODEL = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
+			"geo/entity/races/kiaura.geo.json");
+	private static final ResourceLocation AURA_TEX_0 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
+			"textures/entity/ki/aura_ki_0.png");
+	private static final ResourceLocation AURA_TEX_1 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
+			"textures/entity/ki/aura_ki_1.png");
+	private static final ResourceLocation AURA_TEX_2 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
+			"textures/entity/ki/aura_ki_2.png");
+	private static final ResourceLocation AURA_SLOW_MODEL = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
+			"geo/entity/races/kiaura2.geo.json");
 
-	private static final ResourceLocation SPARK_MODEL = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "geo/entity/races/kirayos.geo.json");
-	private static final ResourceLocation SPARK_TEX_0 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "textures/entity/ki/rayo_0.png");
-	private static final ResourceLocation SPARK_TEX_1 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "textures/entity/ki/rayo_1.png");
-	private static final ResourceLocation SPARK_TEX_2 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "textures/entity/ki/rayo_2.png");
+	private static final ResourceLocation SPARK_MODEL = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
+			"geo/entity/races/kirayos.geo.json");
+	private static final ResourceLocation SPARK_TEX_0 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
+			"textures/entity/ki/rayo_0.png");
+	private static final ResourceLocation SPARK_TEX_1 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
+			"textures/entity/ki/rayo_1.png");
+	private static final ResourceLocation SPARK_TEX_2 = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
+			"textures/entity/ki/rayo_2.png");
 
-	private static final ResourceLocation KI_WEAPONS_MODEL = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "geo/entity/races/kiweapons.geo.json");
-	private static final ResourceLocation KI_WEAPONS_TEXTURE = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "textures/entity/races/kiweapons.png");
+	private static final ResourceLocation KI_WEAPONS_MODEL = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
+			"geo/entity/races/kiweapons.geo.json");
+	private static final ResourceLocation KI_WEAPONS_TEXTURE = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID,
+			"textures/entity/races/kiweapons.png");
 
 	private static final float HALF_SQRT_3 = (float) (Math.sqrt(3.0D) / 2.0D);
 	private static final Map<Integer, Long> FUSION_START_TIME = new HashMap<>();
@@ -122,7 +133,7 @@ public class AuraRenderHandler {
 			sZ = Math.max(0.1f, sZ - 2.8f);
 		}
 
-		return new float[]{sX, sY, sZ};
+		return new float[] { sX, sY, sZ };
 	}
 
 	private static float[] getAuraScale(StatsData stats) {
@@ -140,12 +151,50 @@ public class AuraRenderHandler {
 			scale += 0.2f;
 		}
 
-		return new float[]{scale, scale, scale};
+		return new float[] { scale, scale, scale };
+	}
+
+	private static boolean isKaiokenActive(StatsData stats) {
+		var character = stats.getCharacter();
+		String group = character.getActiveStackFormGroup();
+		if (group != null && "kaioken".equalsIgnoreCase(group))
+			return true;
+
+		String stackForm = character.getActiveStackForm();
+		if (stackForm != null && stackForm.toLowerCase().startsWith("kaioken"))
+			return true;
+
+		return false;
+	}
+
+	private static void renderKaiokenOverlayLayer(Player player, StatsData stats, PoseStack poseStack,
+			MultiBufferSource.BufferSource buffers, BakedGeoModel auraModel, float alpha, float partialTick) {
+		Minecraft mc = Minecraft.getInstance();
+		EntityRenderDispatcher dispatcher = mc.getEntityRenderDispatcher();
+		var genericRenderer = dispatcher.getRenderer(player);
+		if (!(genericRenderer instanceof software.bernie.geckolib.renderer.GeoRenderer renderer))
+			return;
+
+		poseStack.pushPose();
+		float scaleMult = 1.15f;
+		poseStack.scale(scaleMult, scaleMult, scaleMult);
+
+		long frame = (long) ((player.level().getGameTime() / 1.5f) % 3);
+		ResourceLocation currentTexture = (frame == 0) ? AURA_TEX_0 : (frame == 1) ? AURA_TEX_1 : AURA_TEX_2;
+
+		float[] red = ColorUtils.hexToRgb("#DB182C");
+
+		renderer.reRender(auraModel, poseStack, buffers, (GeoAnimatable) player, ModRenderTypes.energy(currentTexture),
+				buffers.getBuffer(ModRenderTypes.energy(currentTexture)), partialTick, 15728880,
+				OverlayTexture.NO_OVERLAY, red[0], red[1], red[2], alpha * 0.8f);
+
+		poseStack.popPose();
 	}
 
 	@SubscribeEvent
 	public static void onRenderLevelStage(RenderLevelStageEvent event) {
-		if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_PARTICLES) return;
+		if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_PARTICLES)
+			return;
 
 		Minecraft mc = Minecraft.getInstance();
 		EntityRenderDispatcher dispatcher = mc.getEntityRenderDispatcher();
@@ -164,7 +213,8 @@ public class AuraRenderHandler {
 				boolean isFused = stats.getStatus().isFused();
 				boolean wasFused = WAS_FUSED_CACHE.getOrDefault(playerId, false);
 
-				if (isFused && !wasFused) FUSION_START_TIME.put(playerId, gameTime);
+				if (isFused && !wasFused)
+					FUSION_START_TIME.put(playerId, gameTime);
 				WAS_FUSED_CACHE.put(playerId, isFused);
 
 				if (FUSION_START_TIME.containsKey(playerId)) {
@@ -178,7 +228,8 @@ public class AuraRenderHandler {
 
 						renderFusionFlash(player, timeSinceStart + partialTick, poseStack, buffers, r, g, b);
 					} else {
-						if (timeSinceStart > 80) FUSION_START_TIME.remove(playerId);
+						if (timeSinceStart > 80)
+							FUSION_START_TIME.remove(playerId);
 					}
 				}
 			}
@@ -224,7 +275,8 @@ public class AuraRenderHandler {
 		}
 
 		PULSE_PROGRESS.keySet().removeIf(id -> !currentFramePlayers.contains(id) && !AURA_CACHE.containsKey(id));
-		PULSE_LAST_RENDER_TIME.keySet().removeIf(id -> !currentFramePlayers.contains(id) && !AURA_CACHE.containsKey(id));
+		PULSE_LAST_RENDER_TIME.keySet()
+				.removeIf(id -> !currentFramePlayers.contains(id) && !AURA_CACHE.containsKey(id));
 		LAST_RENDER_TIME.keySet().removeIf(id -> !currentFramePlayers.contains(id) && !AURA_CACHE.containsKey(id));
 
 		COLOR_PROGRESS_MAP.keySet().removeIf(id -> !currentFramePlayers.contains(id) && !AURA_CACHE.containsKey(id));
@@ -242,14 +294,17 @@ public class AuraRenderHandler {
 		var weapons = AuraRenderQueue.getAndClearWeapons();
 		if (weapons != null && !weapons.isEmpty()) {
 			for (var entry : weapons) {
-				if (entry == null) continue;
+				if (entry == null)
+					continue;
 				var player = entry.player();
-				if (player == null) continue;
+				if (player == null)
+					continue;
 				EntityRenderer<? super Player> genericRenderer = dispatcher.getRenderer(player);
 
 				if (genericRenderer instanceof DMZPlayerRenderer renderer) {
 					BakedGeoModel weaponModel = renderer.getGeoModel().getBakedModel(KI_WEAPONS_MODEL);
-					if (weaponModel == null) continue;
+					if (weaponModel == null)
+						continue;
 
 					resetModelParts(weaponModel);
 					boolean isRight = player.getMainArm() == HumanoidArm.RIGHT;
@@ -324,23 +379,24 @@ public class AuraRenderHandler {
 			destBone.setPosY(sourceBone.getPosY());
 			destBone.setPosZ(sourceBone.getPosZ());
 		});
-		for (GeoBone child : destBone.getChildBones()) syncBoneRecursively(child, sourceModel);
+		for (GeoBone child : destBone.getChildBones())
+			syncBoneRecursively(child, sourceModel);
 	}
 
 	private static String getBaseKiColorHex(StatsData stats) {
 		var character = stats.getCharacter();
 		String kiHex = character.getAuraColor();
 
-		if (character.hasActiveStackForm()
-				&& character.getActiveStackFormData() != null
-				&& character.getActiveStackFormData().getAuraColor() != null
-				&& !character.getActiveStackFormData().getAuraColor().isEmpty()) {
-			kiHex = character.getActiveStackFormData().getAuraColor();
-		} else if (character.hasActiveForm()
+		if (character.hasActiveForm()
 				&& character.getActiveFormData() != null
 				&& character.getActiveFormData().getAuraColor() != null
 				&& !character.getActiveFormData().getAuraColor().isEmpty()) {
 			kiHex = character.getActiveFormData().getAuraColor();
+		} else if (character.hasActiveStackForm()
+				&& character.getActiveStackFormData() != null
+				&& character.getActiveStackFormData().getAuraColor() != null
+				&& !character.getActiveStackFormData().getAuraColor().isEmpty()) {
+			kiHex = character.getActiveStackFormData().getAuraColor();
 		}
 
 		return kiHex;
@@ -359,7 +415,8 @@ public class AuraRenderHandler {
 			if (stats.getStatus().getSelectedAction() == ActionMode.STACK) {
 				nextForm = TransformationsHelper.getNextAvailableStackForm(stats);
 			} else if (stats.getStatus().getSelectedAction() == ActionMode.FORM) {
-				if (!hasStackForm) nextForm = TransformationsHelper.getNextAvailableForm(stats);
+				if (!hasStackForm)
+					nextForm = TransformationsHelper.getNextAvailableForm(stats);
 			}
 
 			if (nextForm != null && nextForm.getAuraColor() != null && !nextForm.getAuraColor().isEmpty()) {
@@ -396,18 +453,23 @@ public class AuraRenderHandler {
 		float g = Mth.lerp(factor, rgbFrom[1], rgbTo[1]);
 		float b = Mth.lerp(factor, rgbFrom[2], rgbTo[2]);
 
-		return new float[]{r, g, b};
+		return new float[] { r, g, b };
 	}
 
-	private static void renderAuraEntry(AuraRenderQueue.AuraRenderEntry entry, PoseStack poseStack, MultiBufferSource.BufferSource buffers, EntityRenderDispatcher dispatcher, Minecraft mc, boolean isActive) {
+	private static void renderAuraEntry(AuraRenderQueue.AuraRenderEntry entry, PoseStack poseStack,
+			MultiBufferSource.BufferSource buffers, EntityRenderDispatcher dispatcher, Minecraft mc, boolean isActive) {
 		var player = entry.player();
-		if (!(player instanceof GeoAnimatable animatable)) return;
+		if (!(player instanceof GeoAnimatable animatable))
+			return;
 		EntityRenderer<? super Player> genericRenderer = dispatcher.getRenderer(player);
-		if (!(genericRenderer instanceof @SuppressWarnings("rawtypes")DMZPlayerRenderer renderer)) return;
+		if (!(genericRenderer instanceof @SuppressWarnings("rawtypes") DMZPlayerRenderer renderer))
+			return;
 		BakedGeoModel auraModel = renderer.getGeoModel().getBakedModel(AURA_MODEL);
-		if (auraModel == null) return;
+		if (auraModel == null)
+			return;
 		var stats = StatsProvider.get(StatsCapability.INSTANCE, player).orElse(null);
-		if (stats == null) return;
+		if (stats == null)
+			return;
 
 		int playerId = player.getId();
 		CachedAuraData data = AURA_CACHE.computeIfAbsent(playerId, k -> new CachedAuraData());
@@ -420,7 +482,8 @@ public class AuraRenderHandler {
 
 		if (data.alphaProgress < 1.0f) {
 			data.alphaProgress += FADE_SPEED;
-			if (data.alphaProgress > 1.0f) data.alphaProgress = 1.0f;
+			if (data.alphaProgress > 1.0f)
+				data.alphaProgress = 1.0f;
 		}
 
 		float[] body = getBodyScale(stats);
@@ -461,19 +524,31 @@ public class AuraRenderHandler {
 					buffers.getBuffer(ModRenderTypes.energy(currentTexture)), entry.partialTick(), 15728880,
 					OverlayTexture.NO_OVERLAY, data.color[0], data.color[1], data.color[2], finalAlpha);
 		}
+
+		if (stats != null && stats.getCharacter().hasActiveForm() && isKaiokenActive(stats)) {
+			renderKaiokenOverlayLayer(player, stats, poseStack, buffers,
+					renderer.getGeoModel().getBakedModel(AURA_MODEL), 0.15f, entry.partialTick());
+		}
+
 		poseStack.popPose();
 	}
 
-	private static boolean renderGhostAura(Player player, CachedAuraData data, PoseStack poseStack, MultiBufferSource.BufferSource buffers, EntityRenderDispatcher dispatcher, Minecraft mc, float partialTick) {
-		if (!(player instanceof GeoAnimatable animatable)) return false;
+	private static boolean renderGhostAura(Player player, CachedAuraData data, PoseStack poseStack,
+			MultiBufferSource.BufferSource buffers, EntityRenderDispatcher dispatcher, Minecraft mc,
+			float partialTick) {
+		if (!(player instanceof GeoAnimatable animatable))
+			return false;
 		EntityRenderer<? super Player> genericRenderer = dispatcher.getRenderer(player);
-		if (!(genericRenderer instanceof @SuppressWarnings("rawtypes")DMZPlayerRenderer renderer)) return false;
+		if (!(genericRenderer instanceof @SuppressWarnings("rawtypes") DMZPlayerRenderer renderer))
+			return false;
 
 		if (data.alphaProgress > 0.0f) {
 			data.alphaProgress -= FADE_SPEED;
-			if (data.alphaProgress < 0.0f) data.alphaProgress = 0.0f;
+			if (data.alphaProgress < 0.0f)
+				data.alphaProgress = 0.0f;
 		}
-		if (data.alphaProgress <= 0.001f) return false;
+		if (data.alphaProgress <= 0.001f)
+			return false;
 
 		Vec3 cameraPos = mc.gameRenderer.getMainCamera().getPosition();
 		double lerpX = Mth.lerp(partialTick, player.xo, player.getX());
@@ -489,8 +564,7 @@ public class AuraRenderHandler {
 		poseStack.scale(
 				data.bodyScaleX * data.auraScaleX,
 				data.bodyScaleY * data.auraScaleY,
-				data.bodyScaleZ * data.auraScaleZ
-		);
+				data.bodyScaleZ * data.auraScaleZ);
 
 		if (data.playerModel != null) {
 			syncModelToPlayer(data.model, data.playerModel);
@@ -507,20 +581,32 @@ public class AuraRenderHandler {
 				buffers.getBuffer(ModRenderTypes.energy(currentTexture)), partialTick, 15728880,
 				OverlayTexture.NO_OVERLAY, data.color[0], data.color[1], data.color[2], finalAlpha);
 
+		StatsData ghostStats = StatsProvider.get(StatsCapability.INSTANCE, player).orElse(null);
+		if (ghostStats != null && ghostStats.getCharacter().hasActiveForm() && isKaiokenActive(ghostStats)) {
+			renderKaiokenOverlayLayer(player, ghostStats, poseStack, buffers,
+					renderer.getGeoModel().getBakedModel(AURA_MODEL), 0.10f, partialTick);
+		}
+
 		poseStack.popPose();
 		return true;
 	}
 
-	private static void renderPulseAura(AuraRenderQueue.AuraRenderEntry entry, PoseStack poseStack, MultiBufferSource.BufferSource buffers, EntityRenderDispatcher dispatcher, Minecraft mc) {
+	private static void renderPulseAura(AuraRenderQueue.AuraRenderEntry entry, PoseStack poseStack,
+			MultiBufferSource.BufferSource buffers, EntityRenderDispatcher dispatcher, Minecraft mc) {
 		var player = entry.player();
-		if (!(player instanceof GeoAnimatable animatable)) return;
+		if (!(player instanceof GeoAnimatable animatable))
+			return;
 		EntityRenderer<? super Player> genericRenderer = dispatcher.getRenderer(player);
-		if (!(genericRenderer instanceof @SuppressWarnings("rawtypes")DMZPlayerRenderer renderer)) return;
+		if (!(genericRenderer instanceof @SuppressWarnings("rawtypes") DMZPlayerRenderer renderer))
+			return;
 		BakedGeoModel slowModel = renderer.getGeoModel().getBakedModel(AURA_SLOW_MODEL);
-		if (slowModel == null) slowModel = renderer.getGeoModel().getBakedModel(AURA_MODEL);
-		if (slowModel == null) return;
+		if (slowModel == null)
+			slowModel = renderer.getGeoModel().getBakedModel(AURA_MODEL);
+		if (slowModel == null)
+			return;
 		var stats = StatsProvider.get(StatsCapability.INSTANCE, player).orElse(null);
-		if (stats == null) return;
+		if (stats == null)
+			return;
 
 		int playerId = player.getId();
 		long gameTime = player.level().getGameTime();
@@ -532,10 +618,12 @@ public class AuraRenderHandler {
 
 		float currentProgress = PULSE_PROGRESS.getOrDefault(playerId, 0.0f);
 		currentProgress += PULSE_SPEED;
-		if (currentProgress > 2.0f) currentProgress = 0.0f;
+		if (currentProgress > 2.0f)
+			currentProgress = 0.0f;
 		PULSE_PROGRESS.put(playerId, currentProgress);
 
-		if (currentProgress >= 1.0f) return;
+		if (currentProgress >= 1.0f)
+			return;
 
 		float expansion = 1.0f + (2.5f * currentProgress);
 		float alphaCurve = (float) Math.sin(currentProgress * Math.PI);
@@ -570,30 +658,45 @@ public class AuraRenderHandler {
 					buffers.getBuffer(ModRenderTypes.energy(currentTexture)), entry.partialTick(), 15728880,
 					OverlayTexture.NO_OVERLAY, color[0], color[1], color[2], finalAlpha);
 		}
+
+		if (stats != null && stats.getCharacter().hasActiveForm() && isKaiokenActive(stats)) {
+			BakedGeoModel model = renderer.getGeoModel().getBakedModel(AURA_SLOW_MODEL);
+			if (model == null)
+				model = renderer.getGeoModel().getBakedModel(AURA_MODEL);
+			renderKaiokenOverlayLayer(player, stats, poseStack, buffers, model, 0.20f, entry.partialTick());
+		}
+
 		poseStack.popPose();
 	}
 
-	private static void renderFirstPersonAura(AuraRenderQueue.FirstPersonAuraEntry entry, PoseStack poseStack, MultiBufferSource.BufferSource buffers, EntityRenderDispatcher dispatcher, Minecraft mc) {
+	private static void renderFirstPersonAura(AuraRenderQueue.FirstPersonAuraEntry entry, PoseStack poseStack,
+			MultiBufferSource.BufferSource buffers, EntityRenderDispatcher dispatcher, Minecraft mc) {
 		Player player = entry.player();
 		float partialTick = entry.partialTick();
-		if (!(player instanceof GeoAnimatable animatable)) return;
+		if (!(player instanceof GeoAnimatable animatable))
+			return;
 		EntityRenderer<? super Player> genericRenderer = dispatcher.getRenderer(player);
-		if (!(genericRenderer instanceof @SuppressWarnings("rawtypes")DMZPlayerRenderer renderer)) return;
+		if (!(genericRenderer instanceof @SuppressWarnings("rawtypes") DMZPlayerRenderer renderer))
+			return;
 		BakedGeoModel auraModel = renderer.getGeoModel().getBakedModel(AURA_MODEL);
-		if (auraModel == null) return;
+		if (auraModel == null)
+			return;
 		var stats = StatsProvider.get(StatsCapability.INSTANCE, player).orElse(null);
-		if (stats == null) return;
+		if (stats == null)
+			return;
 
 		int playerId = player.getId();
 		CachedAuraData data = AURA_CACHE.computeIfAbsent(playerId, k -> new CachedAuraData());
 
 		long gameTime = player.level().getGameTime();
-		if (gameTime - LAST_RENDER_TIME.getOrDefault(playerId, 0L) > 2) data.alphaProgress = 0.0f;
+		if (gameTime - LAST_RENDER_TIME.getOrDefault(playerId, 0L) > 2)
+			data.alphaProgress = 0.0f;
 		LAST_RENDER_TIME.put(playerId, gameTime);
 
 		if (data.alphaProgress < 1.0f) {
 			data.alphaProgress += FADE_SPEED;
-			if (data.alphaProgress > 1.0f) data.alphaProgress = 1.0f;
+			if (data.alphaProgress > 1.0f)
+				data.alphaProgress = 1.0f;
 		}
 
 		float[] body = getBodyScale(stats);
@@ -629,8 +732,7 @@ public class AuraRenderHandler {
 		poseStack.scale(
 				data.bodyScaleX * data.auraScaleX,
 				data.bodyScaleY * data.auraScaleY,
-				data.bodyScaleZ * data.auraScaleZ
-		);
+				data.bodyScaleZ * data.auraScaleZ);
 
 		long frame = (long) ((player.level().getGameTime() / 1.5f) % 3);
 		ResourceLocation currentTexture = (frame == 0) ? AURA_TEX_0 : (frame == 1) ? AURA_TEX_1 : AURA_TEX_2;
@@ -643,6 +745,14 @@ public class AuraRenderHandler {
 					buffers.getBuffer(ModRenderTypes.energy(currentTexture)), partialTick, 15728880,
 					OverlayTexture.NO_OVERLAY, data.color[0], data.color[1], data.color[2], finalAlpha);
 		}
+
+		StatsData firstPersonStats = StatsProvider.get(StatsCapability.INSTANCE, player).orElse(null);
+		if (firstPersonStats != null && firstPersonStats.getCharacter().hasActiveForm()
+				&& isKaiokenActive(firstPersonStats)) {
+			renderKaiokenOverlayLayer(player, firstPersonStats, poseStack, buffers,
+					renderer.getGeoModel().getBakedModel(AURA_MODEL), 0.075f, partialTick);
+		}
+
 		poseStack.popPose();
 
 		if (player.onGround()) {
@@ -651,15 +761,20 @@ public class AuraRenderHandler {
 		}
 	}
 
-	private static void renderSparkEntry(AuraRenderQueue.SparkRenderEntry entry, PoseStack poseStack, MultiBufferSource.BufferSource buffers, EntityRenderDispatcher dispatcher, Minecraft mc) {
+	private static void renderSparkEntry(AuraRenderQueue.SparkRenderEntry entry, PoseStack poseStack,
+			MultiBufferSource.BufferSource buffers, EntityRenderDispatcher dispatcher, Minecraft mc) {
 		var player = entry.player();
-		if (!(player instanceof GeoAnimatable animatable)) return;
+		if (!(player instanceof GeoAnimatable animatable))
+			return;
 		EntityRenderer<? super Player> genericRenderer = dispatcher.getRenderer(player);
-		if (!(genericRenderer instanceof @SuppressWarnings("rawtypes")DMZPlayerRenderer renderer)) return;
+		if (!(genericRenderer instanceof @SuppressWarnings("rawtypes") DMZPlayerRenderer renderer))
+			return;
 		BakedGeoModel sparkModel = renderer.getGeoModel().getBakedModel(SPARK_MODEL);
-		if (sparkModel == null) return;
+		if (sparkModel == null)
+			return;
 		var stats = StatsProvider.get(StatsCapability.INSTANCE, player).orElse(null);
-		if (stats == null) return;
+		if (stats == null)
+			return;
 		var character = stats.getCharacter();
 
 		boolean hasLightning = false;
@@ -681,7 +796,8 @@ public class AuraRenderHandler {
 			}
 		}
 
-		if (!hasLightning) return;
+		if (!hasLightning)
+			return;
 		float[] color = ColorUtils.hexToRgb(lightningColor);
 		float[] scales = getAuraScale(stats);
 
@@ -706,14 +822,17 @@ public class AuraRenderHandler {
 
 	@SubscribeEvent
 	public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
-		if (event.phase != TickEvent.Phase.END || event.side != LogicalSide.CLIENT) return;
+		if (event.phase != TickEvent.Phase.END || event.side != LogicalSide.CLIENT)
+			return;
 
 		Player player = event.player;
 
-		if (!BetaWhitelist.isAllowed(player.getGameProfile().getName())) return;
+		if (!BetaWhitelist.isAllowed(player.getGameProfile().getName()))
+			return;
 
 		var stats = StatsProvider.get(StatsCapability.INSTANCE, player).orElse(null);
-		if (stats == null) return;
+		if (stats == null)
+			return;
 
 		float scale = 1.0f;
 		var character = stats.getCharacter();
@@ -728,8 +847,10 @@ public class AuraRenderHandler {
 			}
 		}
 
-		if (!stats.getStatus().isHasCreatedCharacter()) return;
-		if (!stats.getStatus().isAuraActive() && !stats.getStatus().isPermanentAura()) return;
+		if (!stats.getStatus().isHasCreatedCharacter())
+			return;
+		if (!stats.getStatus().isAuraActive() && !stats.getStatus().isPermanentAura())
+			return;
 
 		float[] rgbColor = getInterpolatedKiColor(player, stats, 1.0f);
 		int r = (int) Math.max(0, Math.min(255, rgbColor[0] * 255));
@@ -737,7 +858,8 @@ public class AuraRenderHandler {
 		int b = (int) Math.max(0, Math.min(255, rgbColor[2] * 255));
 		int particleColor = (r << 16) | (g << 8) | b;
 
-		for (int i = 0; i < 1; i++) spawnCalmAuraParticle(player, scale, particleColor);
+		for (int i = 0; i < 1; i++)
+			spawnCalmAuraParticle(player, scale, particleColor);
 
 		if (player.getRandom().nextInt(20) == 0) {
 			int divineCount = 5 + player.getRandom().nextInt(10);
@@ -747,7 +869,8 @@ public class AuraRenderHandler {
 		}
 	}
 
-	private static void renderFusionFlash(Player player, float time, PoseStack poseStack, MultiBufferSource buffer, int r, int g, int b) {
+	private static void renderFusionFlash(Player player, float time, PoseStack poseStack, MultiBufferSource buffer,
+			int r, int g, int b) {
 		float rotationTime = time * 0.01F;
 		float rawSin = Mth.sin(time * 0.1F);
 		float normalizedFade = (rawSin + 1.0F) / 2.0F;
@@ -764,7 +887,8 @@ public class AuraRenderHandler {
 		double lerpY = Mth.lerp(0, player.yo, player.getY());
 		double lerpZ = Mth.lerp(0, player.zo, player.getZ());
 
-		poseStack.translate(player.getX() - cameraPos.x, (player.getY() + 1.0) - cameraPos.y, player.getZ() - cameraPos.z);
+		poseStack.translate(player.getX() - cameraPos.x, (player.getY() + 1.0) - cameraPos.y,
+				player.getZ() - cameraPos.z);
 
 		poseStack.scale(1.0F, 1.0F, 1.0F);
 
@@ -801,22 +925,25 @@ public class AuraRenderHandler {
 		pConsumer.vertex(pMatrix, 0.0F, 0.0F, 0.0F).color(r, g, b, pAlpha).endVertex();
 	}
 
-	private static void vertex2(VertexConsumer pConsumer, Matrix4f pMatrix, float pWidth, float pLength, int r, int g, int b, int alpha) {
+	private static void vertex2(VertexConsumer pConsumer, Matrix4f pMatrix, float pWidth, float pLength, int r, int g,
+			int b, int alpha) {
 		pConsumer.vertex(pMatrix, -HALF_SQRT_3 * pLength, pWidth, -0.5F * pLength).color(r, g, b, alpha).endVertex();
 	}
 
-	private static void vertex3(VertexConsumer pConsumer, Matrix4f pMatrix, float pWidth, float pLength, int r, int g, int b, int alpha) {
+	private static void vertex3(VertexConsumer pConsumer, Matrix4f pMatrix, float pWidth, float pLength, int r, int g,
+			int b, int alpha) {
 		pConsumer.vertex(pMatrix, HALF_SQRT_3 * pLength, pWidth, -0.5F * pLength).color(r, g, b, alpha).endVertex();
 	}
 
-	private static void vertex4(VertexConsumer pConsumer, Matrix4f pMatrix, float pWidth, float pLength, int r, int g, int b, int alpha) {
+	private static void vertex4(VertexConsumer pConsumer, Matrix4f pMatrix, float pWidth, float pLength, int r, int g,
+			int b, int alpha) {
 		pConsumer.vertex(pMatrix, 0.0F, pWidth, pLength).color(r, g, b, alpha).endVertex();
 	}
 
-
 	private static void spawnCalmAuraParticle(Player player, float totalScale, int colorHex) {
 		var mc = Minecraft.getInstance();
-		if (mc.isPaused()) return;
+		if (mc.isPaused())
+			return;
 		var level = player.level();
 		var random = player.getRandom();
 
@@ -853,7 +980,8 @@ public class AuraRenderHandler {
 
 	private static void spawnPassiveDivineParticle(Player player, float totalScale, int colorHex) {
 		var mc = Minecraft.getInstance();
-		if (mc.isPaused()) return;
+		if (mc.isPaused())
+			return;
 		var level = player.level();
 		var random = player.getRandom();
 
@@ -882,7 +1010,8 @@ public class AuraRenderHandler {
 	}
 
 	private static void spawnGroundDust(Player player, float totalScale) {
-		if (player.getRandom().nextFloat() > 0.3f) return;
+		if (player.getRandom().nextFloat() > 0.3f)
+			return;
 
 		var level = player.level();
 		var random = player.getRandom();
@@ -903,11 +1032,13 @@ public class AuraRenderHandler {
 		double velY = 0.1f;
 		double velZ = Math.sin(angle) * speedBase;
 
-		for (int i = 0; i < 3; i++) level.addParticle(MainParticles.DUST.get(), x, y, z, velX, velY, velZ);
+		for (int i = 0; i < 3; i++)
+			level.addParticle(MainParticles.DUST.get(), x, y, z, velX, velY, velZ);
 	}
 
 	private static void spawnFloatingRubble(Player player, float totalScale) {
-		if (player.getRandom().nextFloat() > 0.15f) return;
+		if (player.getRandom().nextFloat() > 0.15f)
+			return;
 
 		var level = player.level();
 		var random = player.getRandom();


### PR DESCRIPTION
Es una conversión de lo que implementé en el addon: el aura del kaioken por encima del aura de la transformación.
Errores conocidos:
- El código no discrimina entre transformaciones, por lo que, por ejemplo, cuando el jugador se transforme en ozaru con kaioken, tambien va a crear el segundo aura encima del aura base. Una posible solución es detectar si la transformación tiene un color de aura personalizado.
- El aura del kaioken desaparece instantaneamente en vez de desvanecerse (lo mismo al aparecer)