### PR TITLE
Fix ClassCastException in AuraRenderer.processGhostAuras

### DIFF
--- a/src/main/java/com/dragonminez/client/render/effects/AuraRenderer.java
+++ b/src/main/java/com/dragonminez/client/render/effects/AuraRenderer.java
@@ -280,9 +280,8 @@ public class AuraRenderer {
 			CachedAuraData data = entry.getValue();
 
 			if (!currentFramePlayers.contains(playerId)) {
-				Player player = (Player) mc.level.getEntity(playerId);
-
-				if (player == null || !player.isAlive()) {
+				// entity ids get reused, so a cached player id can now point at any entity (e.g. a Bat) -> guard the cast
+				if (!(mc.level.getEntity(playerId) instanceof Player player) || !player.isAlive()) {
 					it.remove();
 					continue;
 				}


### PR DESCRIPTION
## Problem

`AuraRenderer.processGhostAuras` crashes the client with a `ClassCastException`:

```
class net.minecraft.world.entity.ambient.Bat cannot be cast to
class net.minecraft.world.entity.player.Player
  at AuraRenderer.processGhostAuras(AuraRenderer.java:283)
```

Ghost auras are cached by entity id in `AURA_CACHE`. Entity IDs are reused by the game, so after the original player leaves, a cached id can resolve to an unrelated entity (a Bat in this crash). The unchecked `(Player) mc.level.getEntity(playerId)` then throws and takes down the render thread.

## Fix

Replace the unchecked cast with an `instanceof` pattern check. If the id no longer resolves to a live `Player`, the stale cache entry is removed (same behaviour as the previous null/dead check).

```java
if (!(mc.level.getEntity(playerId) instanceof Player player) || !player.isAlive()) {
    it.remove();
    continue;
}
```

Reproduced on 1.20.1 / Forge 47.4.10, DragonMineZ 2.1. Compiles cleanly (`./gradlew compileJava`).