### PR TITLE
Report unknown/misspelled keys in data JSON instead of silently ignoring them

### DIFF
--- a/src/main/java/com/dragonminez/common/alignment/NpcAlignmentRules.java
+++ b/src/main/java/com/dragonminez/common/alignment/NpcAlignmentRules.java
@@ -4,6 +4,8 @@ import com.dragonminez.Env;
 import com.dragonminez.LogUtil;
 import com.dragonminez.Reference;
 import com.dragonminez.common.combat.logic.player.TargetHelper;
+import com.dragonminez.common.diagnostics.JsonKeys;
+import com.dragonminez.common.diagnostics.JsonLoadReport;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
@@ -69,16 +71,31 @@ public final class NpcAlignmentRules {
 		return Map.copyOf(rules);
 	}
 
+	private static final String RULES_LABEL = "npcs/" + RULES_FILE;
+	private static final java.util.Set<String> ROOT_KEYS = java.util.Set.of("npcs");
+	private static final java.util.Set<String> RULE_KEYS = java.util.Set.of("default_relation", "interaction",
+			"hostile_below", "hostile_above", "min_alignment", "max_alignment");
+	private static final java.util.Set<String> INTERACTION_KEYS = java.util.Set.of("min_alignment", "max_alignment");
+
 	private static Map<String, NpcAlignmentRule> parseRules(@Nullable JsonObject root) {
 		Map<String, NpcAlignmentRule> parsed = defaultRules();
 		if (root == null || !root.has("npcs") || !root.get("npcs").isJsonObject()) {
 			return parsed;
 		}
 
+		JsonLoadReport.clear("npc-alignment");
+		JsonKeys.checkObject("npc-alignment", RULES_LABEL, "", root, ROOT_KEYS);
+
 		JsonObject npcs = root.getAsJsonObject("npcs");
 		for (Map.Entry<String, com.google.gson.JsonElement> entry : npcs.entrySet()) {
 			if (!entry.getValue().isJsonObject()) {
 				continue;
+			}
+			JsonObject ruleJson = entry.getValue().getAsJsonObject();
+			JsonKeys.checkObject("npc-alignment", RULES_LABEL, "npcs." + entry.getKey(), ruleJson, RULE_KEYS);
+			if (ruleJson.has("interaction") && ruleJson.get("interaction").isJsonObject()) {
+				JsonKeys.checkObject("npc-alignment", RULES_LABEL, "npcs." + entry.getKey() + ".interaction",
+						ruleJson.getAsJsonObject("interaction"), INTERACTION_KEYS);
 			}
 			NpcAlignmentRule rule = parseRule(entry.getValue().getAsJsonObject());
 			if (rule != null) {

--- a/src/main/java/com/dragonminez/common/config/ConfigLoader.java
+++ b/src/main/java/com/dragonminez/common/config/ConfigLoader.java
@@ -3,7 +3,9 @@ package com.dragonminez.common.config;
 import com.dragonminez.Env;
 import com.dragonminez.LogUtil;
 import com.dragonminez.common.diagnostics.JsonLoadReport;
+import com.dragonminez.common.diagnostics.JsonSchema;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
 import lombok.AllArgsConstructor;
 
@@ -21,7 +23,11 @@ public class ConfigLoader {
 	public <T> T loadConfig(Path path, Class<T> clazz) throws IOException {
 		try {
 			String content = Files.readString(path, StandardCharsets.UTF_8);
-			return gson.fromJson(content, clazz);
+			JsonElement tree = gson.fromJson(content, JsonElement.class);
+			if (tree != null && tree.isJsonObject()) {
+				JsonSchema.check("config", path.getFileName().toString(), "", tree.getAsJsonObject(), clazz);
+			}
+			return gson.fromJson(tree, clazz);
 		} catch (JsonSyntaxException e) {
 			throw new IOException("Invalid JSON syntax in file: " + path.getFileName(), e);
 		} catch (Exception e) {

--- a/src/main/java/com/dragonminez/common/diagnostics/JsonKeys.java
+++ b/src/main/java/com/dragonminez/common/diagnostics/JsonKeys.java
@@ -1,0 +1,45 @@
+package com.dragonminez.common.diagnostics;
+
+import com.google.gson.JsonObject;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public final class JsonKeys {
+
+	private JsonKeys() {}
+
+	private static boolean isComment(String key) {
+		return key.isEmpty() || key.charAt(0) == '_' || key.charAt(0) == '$' || key.startsWith("//");
+	}
+
+	public static Set<String> of(String... keys) {
+		return new HashSet<>(Set.of(keys));
+	}
+
+	public static Set<String> union(Set<String> base, String... extra) {
+		Set<String> result = new HashSet<>(base);
+		for (String key : extra) result.add(key);
+		return result;
+	}
+
+	public static void checkObject(String source, String file, String path, JsonObject json, Set<String> allowed) {
+		if (json == null) return;
+		for (String key : json.keySet()) {
+			if (isComment(key) || allowed.contains(key)) continue;
+			JsonLoadReport.error(source, file, "unknown field '" + key + "'" + at(path) + " (ignored)");
+		}
+	}
+
+	public static void reportBadType(String source, String file, String path, String rawType) {
+		if (rawType == null || rawType.isBlank()) {
+			JsonLoadReport.error(source, file, "missing 'type'" + at(path) + " (entry ignored)");
+		} else {
+			JsonLoadReport.error(source, file, "unknown type '" + rawType + "'" + at(path) + " (entry ignored)");
+		}
+	}
+
+	private static String at(String path) {
+		return (path == null || path.isEmpty()) ? "" : " in " + path;
+	}
+}

--- a/src/main/java/com/dragonminez/common/diagnostics/JsonSchema.java
+++ b/src/main/java/com/dragonminez/common/diagnostics/JsonSchema.java
@@ -1,0 +1,121 @@
+package com.dragonminez.common.diagnostics;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class JsonSchema {
+
+	private JsonSchema() {}
+
+	private static final String CONFIG_PACKAGE = "com.dragonminez.common.config";
+
+	public static void check(String source, String file, String path, JsonObject json, Class<?> type) {
+		if (json == null || type == null || !type.getName().startsWith("com.dragonminez")) return;
+		Map<String, Field> fields = fieldsOf(type);
+		for (Map.Entry<String, JsonElement> entry : json.entrySet()) {
+			String key = entry.getKey();
+			if (isComment(key)) continue;
+			Field field = fields.get(key);
+			if (field == null) {
+				JsonLoadReport.error(source, file, "unknown field '" + key + "'" + at(path) + " (ignored)");
+				continue;
+			}
+			recurse(source, file, path.isEmpty() ? key : path + "." + key, entry.getValue(), field.getGenericType());
+		}
+	}
+
+	private static void recurse(String source, String file, String path, JsonElement value, Type type) {
+		if (value == null || value.isJsonNull()) return;
+		Class<?> raw = rawClass(type);
+
+		if (value.isJsonObject()) {
+			if (isConfigType(raw)) {
+				check(source, file, path, value.getAsJsonObject(), raw);
+			} else if (raw != null && Map.class.isAssignableFrom(raw)) {
+				Class<?> valueType = rawClass(typeArgument(type, 1));
+				if (isConfigType(valueType)) {
+					for (Map.Entry<String, JsonElement> entry : value.getAsJsonObject().entrySet()) {
+						if (entry.getValue().isJsonObject()) {
+							check(source, file, path + "." + entry.getKey(), entry.getValue().getAsJsonObject(), valueType);
+						}
+					}
+				}
+			}
+		} else if (value.isJsonArray()) {
+			Class<?> elementType = raw != null && Collection.class.isAssignableFrom(raw)
+					? rawClass(typeArgument(type, 0))
+					: null;
+			if (isConfigType(elementType)) {
+				JsonArray array = value.getAsJsonArray();
+				for (int i = 0; i < array.size(); i++) {
+					if (array.get(i).isJsonObject()) {
+						check(source, file, path + "[" + i + "]", array.get(i).getAsJsonObject(), elementType);
+					}
+				}
+			}
+		}
+	}
+
+	private static boolean isConfigType(Class<?> type) {
+		return type != null && type.getName().startsWith(CONFIG_PACKAGE) && !hasCustomAdapter(type);
+	}
+
+	// Types with a custom Gson TypeAdapter serialize to a shape that isn't their field layout, so
+	// their inner keys can't be validated by reflection — detect the convention of a nested Adapter.
+	private static boolean hasCustomAdapter(Class<?> type) {
+		for (Class<?> nested : type.getDeclaredClasses()) {
+			if (nested.getSimpleName().equals("Adapter")) return true;
+		}
+		return false;
+	}
+
+	private static Map<String, Field> fieldsOf(Class<?> type) {
+		Map<String, Field> fields = new HashMap<>();
+		for (Class<?> current = type; current != null && current != Object.class; current = current.getSuperclass()) {
+			for (Field field : current.getDeclaredFields()) {
+				int mods = field.getModifiers();
+				if (Modifier.isStatic(mods) || Modifier.isTransient(mods) || field.isSynthetic()) continue;
+				SerializedName serialized = field.getAnnotation(SerializedName.class);
+				if (serialized != null) {
+					fields.putIfAbsent(serialized.value(), field);
+					for (String alternate : serialized.alternate()) fields.putIfAbsent(alternate, field);
+				} else {
+					fields.putIfAbsent(field.getName(), field);
+				}
+			}
+		}
+		return fields;
+	}
+
+	private static Class<?> rawClass(Type type) {
+		if (type instanceof Class<?> c) return c;
+		if (type instanceof ParameterizedType p && p.getRawType() instanceof Class<?> c) return c;
+		return null;
+	}
+
+	private static Type typeArgument(Type type, int index) {
+		if (type instanceof ParameterizedType p) {
+			Type[] args = p.getActualTypeArguments();
+			if (index < args.length) return args[index];
+		}
+		return null;
+	}
+
+	private static boolean isComment(String key) {
+		return key.isEmpty() || key.charAt(0) == '_' || key.charAt(0) == '$' || key.startsWith("//");
+	}
+
+	private static String at(String path) {
+		return (path == null || path.isEmpty()) ? "" : " in " + path;
+	}
+}

--- a/src/main/java/com/dragonminez/common/dragonball/DragonBallPackManager.java
+++ b/src/main/java/com/dragonminez/common/dragonball/DragonBallPackManager.java
@@ -2,11 +2,15 @@ package com.dragonminez.common.dragonball;
 
 import com.dragonminez.Env;
 import com.dragonminez.LogUtil;
+import com.dragonminez.common.diagnostics.JsonKeys;
+import com.dragonminez.common.diagnostics.JsonLoadReport;
+import com.dragonminez.common.diagnostics.JsonSchema;
 import com.dragonminez.common.util.WishTypeAdapter;
 import com.dragonminez.common.wish.Wish;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.minecraftforge.fml.loading.FMLPaths;
 
@@ -62,6 +66,7 @@ public final class DragonBallPackManager {
 	public static LoadedDefinitions getCurrent() { return current; }
 
 	public static LoadedDefinitions loadAll() {
+		JsonLoadReport.clear("dragonballs");
 		LoadedDefinitions loaded = new LoadedDefinitions();
 		List<Path> candidateRoots = getCandidateRootDirectories();
 		for (Path root : candidateRoots) {
@@ -123,13 +128,54 @@ public final class DragonBallPackManager {
 		}
 	}
 
+	private static final Set<String> BALLSET_KEYS = Set.of("id", "dimensions", "copies", "spawn_range",
+			"summon_radius", "blocks", "asset_definition", "display_name");
+	private static final Set<String> RADAR_KEYS = Set.of("id", "item_registry_name", "dimensions", "ball_set",
+			"tooltip_key", "ranges", "recipe_definition", "asset_definition", "chip_item", "cpu_item",
+			"chip_model_item", "cpu_model_item", "display_name");
+	private static final Set<String> DRAGON_KEYS = Set.of("id", "entity_registry_name", "entity_width",
+			"entity_height", "dimensions", "ball_set", "wish_screen_id", "wish_count", "asset_definition");
+	private static final Set<String> WISHES_FILE_KEYS = Set.of("dragon", "wishes");
+	private static final Set<String> BALLSET_ASSET_KEYS = Set.of("id", "flat_texture_prefix",
+			"inventory_texture_format", "geo_model", "animation", "geo_texture_prefix",
+			"block_model_template", "item_model_template");
+	private static final Set<String> RADAR_ASSET_KEYS = Set.of("id", "item_model", "item_texture",
+			"radar_background_texture", "radar_dot_texture", "radar_overlay_texture");
+	private static final Set<String> DRAGON_ASSET_KEYS = Set.of("id", "renderer_type", "model", "texture", "animation");
+
+	private static String label(String normalizedPath) {
+		int index = normalizedPath.indexOf(ROOT_FOLDER_NAME + "/");
+		return index >= 0 ? normalizedPath.substring(index) : normalizedPath;
+	}
+
+	private static void validateWishArray(String file, JsonObject root) {
+		if (!root.has("wishes") || !root.get("wishes").isJsonArray()) return;
+		int i = 0;
+		for (JsonElement element : root.getAsJsonArray("wishes")) {
+			if (element.isJsonObject()) {
+				JsonObject wish = element.getAsJsonObject();
+				String type = wish.has("type") && !wish.get("type").isJsonNull() ? wish.get("type").getAsString() : null;
+				Class<? extends Wish> target = WishTypeAdapter.classForType(type);
+				if (target == null) {
+					JsonKeys.reportBadType("dragonballs", file, "wishes[" + i + "]", type);
+				} else {
+					JsonSchema.check("dragonballs", file, "wishes[" + i + "]", wish, target);
+				}
+			}
+			i++;
+		}
+	}
+
 	private static void readDefinition(String normalizedPath, JsonObject root, LoadedDefinitions loaded) {
+		String file = label(normalizedPath);
 		if (normalizedPath.endsWith("/definitions/ballset.json")) {
+			JsonKeys.checkObject("dragonballs", file, "ballset", root, BALLSET_KEYS);
 			DragonBallSetDefinition definition = DragonBallSetDefinition.fromJson(root);
 			loaded.ballSets.put(definition.getId(), definition);
 			return;
 		}
 		if (normalizedPath.endsWith("/definitions/radar.json")) {
+			JsonKeys.checkObject("dragonballs", file, "radar", root, RADAR_KEYS);
 			DragonRadarDefinition definition = DragonRadarDefinition.fromJson(root);
 			loaded.radars.put(definition.getId(), definition);
 			if (definition.getRecipeDefinitionId().isPresent()) {
@@ -146,11 +192,14 @@ public final class DragonBallPackManager {
 			return;
 		}
 		if (normalizedPath.endsWith("/definitions/dragon.json")) {
+			JsonKeys.checkObject("dragonballs", file, "dragon", root, DRAGON_KEYS);
 			DragonDefinition definition = DragonDefinition.fromJson(root);
 			loaded.dragons.put(definition.getId(), definition);
 			return;
 		}
 		if (normalizedPath.endsWith("/definitions/wishes.json")) {
+			JsonKeys.checkObject("dragonballs", file, "wishes", root, WISHES_FILE_KEYS);
+			validateWishArray(file, root);
 			if (root.has("dragon") && root.has("wishes")) {
 				String dragonId = root.get("dragon").getAsString();
 				List<Wish> wishes = GSON.fromJson(root.getAsJsonArray("wishes"), WISH_LIST_TYPE);
@@ -159,16 +208,19 @@ public final class DragonBallPackManager {
 			return;
 		}
 		if (normalizedPath.endsWith("/assets/ballset.json")) {
+			JsonKeys.checkObject("dragonballs", file, "ballset asset", root, BALLSET_ASSET_KEYS);
 			DragonBallSetAssetDefinition definition = DragonBallSetAssetDefinition.fromJson(root);
 			loaded.ballSetAssets.put(definition.getId(), definition);
 			return;
 		}
 		if (normalizedPath.endsWith("/assets/radar.json")) {
+			JsonKeys.checkObject("dragonballs", file, "radar asset", root, RADAR_ASSET_KEYS);
 			DragonRadarAssetDefinition definition = DragonRadarAssetDefinition.fromJson(root);
 			loaded.radarAssets.put(definition.getId(), definition);
 			return;
 		}
 		if (normalizedPath.endsWith("/assets/dragon.json")) {
+			JsonKeys.checkObject("dragonballs", file, "dragon asset", root, DRAGON_ASSET_KEYS);
 			DragonAssetDefinition definition = DragonAssetDefinition.fromJson(root);
 			loaded.dragonAssets.put(definition.getId(), definition);
 		}

--- a/src/main/java/com/dragonminez/common/quest/QuestParser.java
+++ b/src/main/java/com/dragonminez/common/quest/QuestParser.java
@@ -17,6 +17,7 @@ import com.dragonminez.common.quest.rewards.KiTechniqueReward;
 import com.dragonminez.common.quest.rewards.SkillReward;
 import com.dragonminez.common.quest.rewards.TPSReward;
 import com.dragonminez.common.quest.rewards.TransformationReward;
+import com.dragonminez.common.diagnostics.JsonKeys;
 import com.dragonminez.common.stats.techniques.KiAttackData;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -480,5 +481,138 @@ public class QuestParser {
 			case GAME_TIME -> json.has("ticks") ? Math.max(0L, json.get("ticks").getAsLong()) : 0L;
 			case REAL_TIME -> json.has("milliseconds") ? Math.max(0L, json.get("milliseconds").getAsLong()) : 0L;
 		};
+	}
+
+	private static final Set<String> QUEST_KEYS = Set.of(
+			"id", "title", "type", "description", "category", "parallel_objectives", "party_scaling",
+			"quest_giver", "turn_in", "secret", "claim_mode", "prerequisites", "requirements",
+			"objectives", "rewards", "defaultsVersion");
+
+	private static final Set<String> CONDITION_BLOCK_KEYS = Set.of("operator", "conditions");
+	private static final Set<String> STRUCTURE_HINT_KEYS = Set.of("dimension", "x", "y", "z");
+	private static final Set<String> SAGA_KEYS = Set.of("id", "name", "requirements", "questFolder", "defaultsVersion");
+	private static final Set<String> SAGA_REQUIREMENT_KEYS = Set.of("previousSaga");
+
+	public static void validate(String source, String file, JsonObject json) {
+		if (json == null) return;
+		JsonKeys.checkObject(source, file, "quest", json, QUEST_KEYS);
+
+		if (json.has("objectives") && json.get("objectives").isJsonArray()) {
+			int i = 0;
+			for (JsonElement element : json.getAsJsonArray("objectives")) {
+				if (element.isJsonObject()) validateObjective(source, file, "objectives[" + i + "]", element.getAsJsonObject());
+				i++;
+			}
+		}
+
+		if (json.has("rewards") && json.get("rewards").isJsonArray()) {
+			int i = 0;
+			for (JsonElement element : json.getAsJsonArray("rewards")) {
+				if (element.isJsonObject()) validateReward(source, file, "rewards[" + i + "]", element.getAsJsonObject());
+				i++;
+			}
+		}
+
+		validateConditionsBlock(source, file, json, "prerequisites");
+		validateConditionsBlock(source, file, json, "requirements");
+	}
+
+	public static void validateSaga(String source, String file, JsonObject json) {
+		if (json == null) return;
+		JsonKeys.checkObject(source, file, "saga", json, SAGA_KEYS);
+		if (json.has("requirements") && json.get("requirements").isJsonObject()) {
+			JsonKeys.checkObject(source, file, "requirements", json.getAsJsonObject("requirements"), SAGA_REQUIREMENT_KEYS);
+		}
+	}
+
+	private static void validateObjective(String source, String file, String path, JsonObject json) {
+		String type = json.has("type") && !json.get("type").isJsonNull() ? json.get("type").getAsString().toUpperCase() : null;
+		Set<String> allowed;
+		switch (type == null ? "" : type) {
+			case "ITEM" -> allowed = JsonKeys.of("type", "item", "count");
+			case "KILL" -> allowed = JsonKeys.of("type", "entity", "count", "health", "meleeDamage", "kiDamage",
+					"spawn", "count_mode", "TextureVariant", "AITier", "canTransform", "TransformHealth",
+					"TransformMeleeDamage", "TransformKiDamage", "TransformHealthMultiplier",
+					"TransformMeleeDamageMultiplier", "TransformKiMultiplier", "TransformTriggerPercent");
+			case "BIOME" -> allowed = JsonKeys.of("type", "biome");
+			case "DIMENSION" -> allowed = JsonKeys.of("type", "dimension");
+			case "COORDS" -> allowed = JsonKeys.of("type", "x", "y", "z", "radius");
+			case "INTERACT" -> allowed = JsonKeys.of("type", "entity", "entityName");
+			case "STRUCTURE" -> allowed = JsonKeys.of("type", "structure");
+			case "DRAGON_SUMMON" -> allowed = JsonKeys.of("type", "dragon", "dragon_id", "dragonId",
+					"ball_set", "ballSet", "ball_set_id", "ballSetId", "set");
+			case "TALK_TO" -> allowed = JsonKeys.of("type", "npcId");
+			case "SKILL" -> allowed = JsonKeys.of("type", "skill", "skillId", "id", "level", "minLevel", "required");
+			default -> { JsonKeys.reportBadType(source, file, path, type); return; }
+		}
+		JsonKeys.checkObject(source, file, path, json, allowed);
+	}
+
+	private static void validateReward(String source, String file, String path, JsonObject json) {
+		String type = json.has("type") && !json.get("type").isJsonNull() ? json.get("type").getAsString().toUpperCase() : null;
+		Set<String> common = JsonKeys.of("type", "difficulty", "difficulties", "difficultyType", "minDifficulty");
+		Set<String> allowed;
+		switch (type == null ? "" : type) {
+			case "ITEM" -> allowed = JsonKeys.union(common, "item", "count");
+			case "TPS" -> allowed = JsonKeys.union(common, "amount");
+			case "ALIGNMENT" -> allowed = JsonKeys.union(common, "amount");
+			case "COMMAND" -> allowed = JsonKeys.union(common, "command", "translationKey");
+			case "SKILL" -> allowed = JsonKeys.union(common, "skill", "level");
+			case "TRANSFORMATION" -> allowed = JsonKeys.union(common, "formGroup", "form_group", "group",
+					"formName", "form_name", "form", "mastery", "stack");
+			case "KI_TECHNIQUE" -> allowed = JsonKeys.union(common, "code", "techniqueCode", "technique_code");
+			default -> { JsonKeys.reportBadType(source, file, path, type); return; }
+		}
+		JsonKeys.checkObject(source, file, path, json, allowed);
+	}
+
+	private static void validateConditionsBlock(String source, String file, JsonObject parent, String key) {
+		if (!parent.has(key) || !parent.get(key).isJsonObject()) return;
+		JsonObject block = parent.getAsJsonObject(key);
+		JsonKeys.checkObject(source, file, key, block, CONDITION_BLOCK_KEYS);
+		validateConditionArray(source, file, key, block);
+	}
+
+	private static void validateConditionArray(String source, String file, String path, JsonObject block) {
+		if (!block.has("conditions") || !block.get("conditions").isJsonArray()) return;
+		int i = 0;
+		for (JsonElement element : block.getAsJsonArray("conditions")) {
+			if (element.isJsonObject()) validateCondition(source, file, path + ".conditions[" + i + "]", element.getAsJsonObject());
+			i++;
+		}
+	}
+
+	private static void validateCondition(String source, String file, String path, JsonObject json) {
+		if (json.has("operator")) {
+			JsonKeys.checkObject(source, file, path, json, CONDITION_BLOCK_KEYS);
+			validateConditionArray(source, file, path, json);
+			return;
+		}
+
+		String type = json.has("type") && !json.get("type").isJsonNull() ? json.get("type").getAsString().toUpperCase() : null;
+		Set<String> allowed;
+		switch (type == null ? "" : type) {
+			case "SAGA_QUEST" -> allowed = JsonKeys.of("type", "sagaId", "questId");
+			case "QUEST" -> allowed = JsonKeys.of("type", "questId");
+			case "STAT" -> allowed = JsonKeys.of("type", "stat", "minValue");
+			case "LEVEL" -> allowed = JsonKeys.of("type", "minLevel");
+			case "BIOME" -> allowed = JsonKeys.of("type", "biome");
+			case "STRUCTURE" -> { validateStructureCondition(source, file, path, json); return; }
+			case "DIMENSION" -> allowed = JsonKeys.of("type", "dimension");
+			case "TIME" -> allowed = JsonKeys.of("type", "mode", "ticks", "milliseconds");
+			case "ALIGNMENT" -> allowed = JsonKeys.of("type", "min", "max");
+			case "SKILL" -> allowed = JsonKeys.of("type", "skill", "skillId", "id", "minLevel", "level", "required");
+			case "RACE" -> allowed = JsonKeys.of("type", "race", "raceName", "race_name");
+			case "CLASS" -> allowed = JsonKeys.of("type", "class", "className", "class_name", "characterClass");
+			default -> { JsonKeys.reportBadType(source, file, path, type); return; }
+		}
+		JsonKeys.checkObject(source, file, path, json, allowed);
+	}
+
+	private static void validateStructureCondition(String source, String file, String path, JsonObject json) {
+		JsonKeys.checkObject(source, file, path, json, JsonKeys.of("type", "structure", "hint"));
+		if (json.has("hint") && json.get("hint").isJsonObject()) {
+			JsonKeys.checkObject(source, file, path + ".hint", json.getAsJsonObject("hint"), STRUCTURE_HINT_KEYS);
+		}
 	}
 }

--- a/src/main/java/com/dragonminez/common/quest/QuestRegistry.java
+++ b/src/main/java/com/dragonminez/common/quest/QuestRegistry.java
@@ -262,6 +262,7 @@ public class QuestRegistry extends SimplePreparableReloadListener<Map<String, Qu
 	private static void loadSingleSagaFile(Path file) {
 		try (Reader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
 			JsonObject root = GSON.fromJson(reader, JsonObject.class);
+			QuestParser.validateSaga("quests", "sagas/" + file.getFileName(), root);
 			Saga saga = parseSagaFromJson(root, cachedWorldFolder);
 			LOADED_SAGAS.put(saga.getId(), saga);
 
@@ -345,6 +346,7 @@ public class QuestRegistry extends SimplePreparableReloadListener<Map<String, Qu
 			for (Path file : files) {
 				try (Reader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
 					JsonObject root = GSON.fromJson(reader, JsonObject.class);
+					QuestParser.validate("quests", "quests/" + folder.getFileName() + "/" + file.getFileName(), root);
 					Quest quest = QuestParser.parseQuest(root);
 					if (quest != null) quests.add(quest);
 				} catch (Exception e) {
@@ -385,6 +387,7 @@ public class QuestRegistry extends SimplePreparableReloadListener<Map<String, Qu
 	private static void loadSingleSideQuestFile(Path file) {
 		try (Reader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
 			JsonObject root = GSON.fromJson(reader, JsonObject.class);
+			QuestParser.validate("quests", "sidequests/" + file.getFileName(), root);
 			Quest quest = QuestParser.parseQuest(root);
 
 			if (quest != null) {

--- a/src/main/java/com/dragonminez/common/util/WishTypeAdapter.java
+++ b/src/main/java/com/dragonminez/common/util/WishTypeAdapter.java
@@ -20,18 +20,27 @@ public class WishTypeAdapter implements JsonSerializer<Wish>, JsonDeserializer<W
 		JsonObject jsonObject = json.getAsJsonObject();
 		String type = jsonObject.get(TYPE).getAsString();
 
+		Class<? extends Wish> target = classForType(type);
+		if (target == null) {
+			throw new JsonParseException("Unknown wish type: " + type);
+		}
+		return new GsonBuilder().create().fromJson(json, target);
+	}
+
+	public static Class<? extends Wish> classForType(String type) {
+		if (type == null) return null;
 		return switch (type) {
-			case "item" -> new GsonBuilder().create().fromJson(json, ItemWish.class);
-			case "command" -> new GsonBuilder().create().fromJson(json, CommandWish.class);
-			case "tps" -> new GsonBuilder().create().fromJson(json, TPSWish.class);
-			case "multi_wish" -> new GsonBuilder().create().fromJson(json, MultiItemWish.class);
-			case "skill" -> new GsonBuilder().create().fromJson(json, SkillWish.class);
-			case "passivereset" -> new GsonBuilder().create().fromJson(json, PassiveResetWish.class);
-			case "recustomize" -> new GsonBuilder().create().fromJson(json, ReCustomizeWish.class);
-			case "relocatestats" -> new GsonBuilder().create().fromJson(json, RelocateStatsWish.class);
-			case "changedifficulty" -> new GsonBuilder().create().fromJson(json, ChangeDifficultyWish.class);
-			case "resetstory" -> new GsonBuilder().create().fromJson(json, ResetStoryWish.class);
-			default -> throw new JsonParseException("Unknown wish type: " + type);
+			case "item" -> ItemWish.class;
+			case "command" -> CommandWish.class;
+			case "tps" -> TPSWish.class;
+			case "multi_wish" -> MultiItemWish.class;
+			case "skill" -> SkillWish.class;
+			case "passivereset" -> PassiveResetWish.class;
+			case "recustomize" -> ReCustomizeWish.class;
+			case "relocatestats" -> RelocateStatsWish.class;
+			case "changedifficulty" -> ChangeDifficultyWish.class;
+			case "resetstory" -> ResetStoryWish.class;
+			default -> null;
 		};
 	}
 }

--- a/src/main/java/com/dragonminez/common/wish/WishManager.java
+++ b/src/main/java/com/dragonminez/common/wish/WishManager.java
@@ -2,7 +2,9 @@ package com.dragonminez.common.wish;
 
 import com.dragonminez.Env;
 import com.dragonminez.LogUtil;
+import com.dragonminez.common.diagnostics.JsonKeys;
 import com.dragonminez.common.diagnostics.JsonLoadReport;
+import com.dragonminez.common.diagnostics.JsonSchema;
 import com.dragonminez.common.util.WishTypeAdapter;
 import com.dragonminez.common.wish.wishes.*;
 import com.google.common.reflect.TypeToken;
@@ -79,6 +81,7 @@ public class WishManager {
 			JsonArray rootArray = GSON.fromJson(Files.readString(path), JsonArray.class);
 			List<Wish> wishes = new ArrayList<>();
 			for (JsonElement element : rootArray) {
+				validateWish("wishes/" + path.getFileName(), element);
 				wishes.add(GSON.fromJson(element, Wish.class));
 			}
 			String dragonId = path.getFileName().toString().replace(".json", "");
@@ -87,6 +90,18 @@ public class WishManager {
 		} catch (Exception e) {
 			LogUtil.error(Env.COMMON, "Failed to load dragon wish config '{}': {}", path.getFileName(), e.toString());
 			JsonLoadReport.error("wishes", "wishes/" + path.getFileName(), "Malformed wish JSON, file skipped: " + JsonLoadReport.rootCause(e));
+		}
+	}
+
+	private static void validateWish(String file, JsonElement element) {
+		if (element == null || !element.isJsonObject()) return;
+		JsonObject obj = element.getAsJsonObject();
+		String type = obj.has("type") && !obj.get("type").isJsonNull() ? obj.get("type").getAsString() : null;
+		Class<? extends Wish> target = WishTypeAdapter.classForType(type);
+		if (target == null) {
+			JsonKeys.reportBadType("wishes", file, "wish", type);
+		} else {
+			JsonSchema.check("wishes", file, "wish", obj, target);
 		}
 	}
 

--- a/src/main/java/com/dragonminez/server/world/npc/NPCPlacementManager.java
+++ b/src/main/java/com/dragonminez/server/world/npc/NPCPlacementManager.java
@@ -4,6 +4,8 @@ import com.dragonminez.Env;
 import com.dragonminez.LogUtil;
 import com.dragonminez.Reference;
 import com.dragonminez.common.alignment.NpcDispositionService;
+import com.dragonminez.common.diagnostics.JsonKeys;
+import com.dragonminez.common.diagnostics.JsonLoadReport;
 import com.dragonminez.common.init.entities.questnpc.QuestNPCEntity;
 import com.dragonminez.server.world.structure.helper.DMZStructures;
 import com.dragonminez.server.world.structure.helper.StructureLocator;
@@ -125,17 +127,28 @@ public final class NPCPlacementManager {
 		}
 	}
 
+	private static final String PLACEMENTS_LABEL = "npcs/" + PLACEMENTS_FILE;
+	private static final java.util.Set<String> ROOT_KEYS = java.util.Set.of("placements", "schema");
+	private static final java.util.Set<String> PLACEMENT_KEYS = java.util.Set.of("id", "entity", "dimension",
+			"npc_id", "model", "texture", "structure", "x", "y", "z", "yaw", "pitch", "surface",
+			"relative_to_spawn", "enabled", "override", "alignment", "relation");
+
 	private static List<NPCPlacement> parsePlacements(@Nullable JsonObject root) {
 		if (root == null || !root.has("placements") || !root.get("placements").isJsonArray()) {
 			return List.of();
 		}
 
+		JsonLoadReport.clear("npcs");
+		JsonKeys.checkObject("npcs", PLACEMENTS_LABEL, "", root, ROOT_KEYS);
+
 		List<NPCPlacement> parsed = new ArrayList<>();
+		int index = 0;
 		for (JsonElement element : root.getAsJsonArray("placements")) {
 			if (!element.isJsonObject()) {
 				continue;
 			}
 
+			JsonKeys.checkObject("npcs", PLACEMENTS_LABEL, "placements[" + index++ + "]", element.getAsJsonObject(), PLACEMENT_KEYS);
 			NPCPlacement placement = parsePlacement(element.getAsJsonObject());
 			if (placement != null) {
 				parsed.add(placement);


### PR DESCRIPTION
## Why

A misspelled or wrong-cased field in an editable JSON file used to be silently dropped, so the setting simply never took effect with no feedback (e.g. a kill objective written with the wrong-cased key). This makes those mistakes visible.

## What

Adds strict key validation across the mod's editable JSON. Unknown fields — and unknown/missing `type` discriminators — are surfaced through the existing `JsonLoadReport` (console report + opt-in in-game `reportJsonProblemsInChat` notice) instead of being ignored. **Non-destructive**: files still load; a bad key is just reported.

Two helpers in `common/diagnostics/`:
- `JsonKeys` — explicit per-schema allow-lists (for hand-written parsers; precise).
- `JsonSchema` — reflection check for Gson POJOs; honors `@SerializedName`, skips `static`/`transient` and custom-adapter types, only validates `com.dragonminez` classes.

### Coverage
- **Quests / sagas / side-quests** — every quest, objective (per type), reward (per type), condition, structure hint, saga manifest.
- **Config** — one wiring point in `ConfigLoader` validates every config file (race stats/character, forms, combat, training, skills, techniques, entities).
- **Wishes** — per concrete wish subtype.
- **Dragonball packs** — all definition types + in-pack wishes.
- **NPC placements** and **NPC alignment rules**.

Keys prefixed with `_`, `//`, or `$` are treated as comments and never flagged.

### Deliberately skipped
Hair (no JSON loader), weapon attributes (BetterCombat datapack format — foreign schema), player-data storage (internal save format).

## Notes for review
- All mod-generated defaults were verified to pass their allow-lists (quest/saga `defaultsVersion`, placements `schema`, all default quest/objective/reward/condition keys).
- `JsonSchema` bails out unless the target class is `com.dragonminez.*`, so a `Map`/`JsonObject` handed to `loadConfig` won't flag every key.
- Custom-adapter detection is a convention (nested class named `Adapter` ⇒ don't recurse), currently matching `FormSkillCost`.
- An outdated config may momentarily report removed-field keys until the three-way merge rewrites it (non-destructive, clears next load).

Compiles (`compileJava`, BUILD SUCCESSFUL). Not runtime-tested in a live world.