### PR TITLE
Fix AREA and SHIELD heal/buff ki techniques never gaining XP

### DIFF
--- a/src/main/java/com/dragonminez/common/init/entities/ki/KiAreaEntity.java
+++ b/src/main/java/com/dragonminez/common/init/entities/ki/KiAreaEntity.java
@@ -132,6 +132,7 @@ public class KiAreaEntity extends AbstractKiProjectile {
             if (this.isHeal()) {
                 if (target == this.getOwner() || !this.shouldDamage(target)) {
                     this.applyDamageOrHeal(target, this.getDamagePerHit());
+                    this.onSuccessfulHit(target);
                 }
             } else {
                 if (target != this.getOwner() && this.shouldDamage(target)) {

--- a/src/main/java/com/dragonminez/common/init/entities/ki/KiBarrierEntity.java
+++ b/src/main/java/com/dragonminez/common/init/entities/ki/KiBarrierEntity.java
@@ -259,7 +259,10 @@ public class KiBarrierEntity extends AbstractKiProjectile {
                 if (this.isHeal()) {
                     if (this.tickCount % HEAL_BUFF_INTERVAL == 0) {
                         LivingEntity target = getAnchor();
-                        if (target != null) this.applyTechniqueSecondaryEffect(target);
+                        if (target != null) {
+                            this.applyTechniqueSecondaryEffect(target);
+                            this.onSuccessfulHit(target);
+                        }
                     }
                 } else {
                     pushEntitiesAway();


### PR DESCRIPTION
## Summary
- `KiAreaEntity.applyAreaEffects()` heal branch now calls `onSuccessfulHit()`, matching the damage branch
- `KiBarrierEntity` SHIELD heal/buff pulse now also calls `onSuccessfulHit()` when applying the secondary effect

Previously, `AREA` and `SHIELD` heal/buff ki techniques never granted technique XP, so they could never level up, unlike `SMALL_BALL` and explosion-type techniques which already called `onSuccessfulHit()`.

## Test plan
- [ ] `runClient`/`runServer` smoke test: cast an AREA heal technique and a SHIELD heal technique and confirm technique XP increases

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEdYHeMoiziHbFLmU6AU9m)_