### PR TITLE
Fix Brave Sword scabbard and Power Pole holster vanishing from the player's back

### DIFF
--- a/src/main/java/com/dragonminez/common/init/item/weapons/render/BraveSwordRenderer.java
+++ b/src/main/java/com/dragonminez/common/init/item/weapons/render/BraveSwordRenderer.java
@@ -9,6 +9,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
+import software.bernie.geckolib.cache.object.GeoBone;
 import software.bernie.geckolib.renderer.GeoItemRenderer;
 
 public class BraveSwordRenderer extends GeoItemRenderer<BraveSwordItem> {
@@ -20,11 +21,17 @@ public class BraveSwordRenderer extends GeoItemRenderer<BraveSwordItem> {
 	@Override
 	public void actuallyRender(PoseStack poseStack, BraveSwordItem animatable, BakedGeoModel model, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
 
-		model.getBone("cubretodo").ifPresent(bone -> {
-			bone.setHidden(true);
-		});
+		// Hide the scabbard while the sword is held, then put it back. BakedGeoModel
+		// instances are cached per model file in GeckoLibCache and shared by every
+		// renderer that uses them, so leaving the bone hidden here also hides it in
+		// DMZRacePartsLayer, which draws the sheathed sword on the player's back.
+		GeoBone sheath = model.getBone("cubretodo").orElse(null);
+		boolean wasHidden = sheath != null && sheath.isHidden();
+		if (sheath != null) sheath.setHidden(true);
 
 		super.actuallyRender(poseStack, animatable, model, renderType, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, red, green, blue, alpha);
+
+		if (sheath != null) sheath.setHidden(wasHidden);
 
 	}
 

--- a/src/main/java/com/dragonminez/common/init/item/weapons/render/PowerPoleRenderer.java
+++ b/src/main/java/com/dragonminez/common/init/item/weapons/render/PowerPoleRenderer.java
@@ -9,6 +9,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
+import software.bernie.geckolib.cache.object.GeoBone;
 import software.bernie.geckolib.renderer.GeoItemRenderer;
 
 public class PowerPoleRenderer extends GeoItemRenderer<PowerPoleItem> {
@@ -20,11 +21,17 @@ public class PowerPoleRenderer extends GeoItemRenderer<PowerPoleItem> {
 	@Override
 	public void actuallyRender(PoseStack poseStack, PowerPoleItem animatable, BakedGeoModel model, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
 
-		model.getBone("cubretodo").ifPresent(bone -> {
-			bone.setHidden(true);
-		});
+		// Hide the holster while the pole is held, then put it back. BakedGeoModel
+		// instances are cached per model file in GeckoLibCache and shared by every
+		// renderer that uses them, so leaving the bone hidden here also hides it in
+		// DMZRacePartsLayer, which draws the stowed pole on the player's back.
+		GeoBone holster = model.getBone("cubretodo").orElse(null);
+		boolean wasHidden = holster != null && holster.isHidden();
+		if (holster != null) holster.setHidden(true);
 
 		super.actuallyRender(poseStack, animatable, model, renderType, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, red, green, blue, alpha);
+
+		if (holster != null) holster.setHidden(wasHidden);
 
 	}
 


### PR DESCRIPTION
## Summary

The Brave Sword renders on the player's back as a bare blade with no scabbard, and the Power Pole renders without its holster. Both are supposed to be sheathed there, and both models already contain the geometry for it.

The cause is a hidden bone that is never restored. Because GeckoLib caches one `BakedGeoModel` per model file and shares it process-wide, hiding a bone in the item renderer also hides it in the player layer that draws the stowed weapon.

Previously reported in #224.

## Reproduction

1. Create a character (the back render is gated on `isHasCreatedCharacter`).
2. Put a Brave Sword in the inventory without holding it. In third person the sword appears on the back, correctly sheathed. This is the control.
3. Hold the sword in the main hand for one frame.
4. Switch to a different hotbar slot so it returns to the back.
5. The scabbard is now gone and only the bare blade renders. It stays that way until F3+T or a restart.

Note that step 3 does not have to be performed by you. Any player, or an armour stand, holding a Brave Sword anywhere in render distance produces the same result on your client, because the affected state is global rather than per-entity.

The same sequence with a Power Pole removes its holster.

## Root cause

`BraveSwordRenderer.actuallyRender` hides the `cubretodo` bone so the scabbard does not render while the sword is in hand, but never restores it:

```java
model.getBone("cubretodo").ifPresent(bone -> {
    bone.setHidden(true);
});

super.actuallyRender(...);
```

That would be harmless if the model were per-renderer, but it is not:

- `GeoModel.getBakedModel(ResourceLocation)` returns the instance held in `GeckoLibCache.MODELS`, a static `Map<ResourceLocation, BakedGeoModel>`. It is returned as-is, with no copy.
- `BakedGeoModel` wraps a `List<GeoBone>`, and `GeoBone.hidden` is a mutable instance field.
- `BraveSwordModel` and `DMZRacePartsLayer.BRAVE_SWORD_MODEL` resolve the same `dragonminez:geo/weapons/brave_sword.geo.json`, so both paths receive the same `GeoBone` object.

`DMZRacePartsLayer.renderSword` then renders the back weapon by recursing from `espadatrunks`, which parents both `cubretodo` (the scabbard) and `espada` (the sword). With `cubretodo` left hidden, only `espada` draws.

This also explains the second symptom described in #224, that the blade looks flat. The blade cubes in `brave_sword.geo.json` are zero-thickness planes, which is fine while they are inside an opaque scabbard but obvious once the scabbard stops rendering. Both symptoms have this single cause.

`PowerPoleRenderer` has the identical omission, with `cubretodo` as a sibling of `palo` under the `baculo` anchor.

## The fix

Capture the previous visibility, hide the bone for the held render, and restore it afterwards. This matches the idiom already used elsewhere in the codebase, for example `DMZRacePartsLayer` lines 521 to 527 for the cape and `DMZPOVPlayerRenderer` lines 66 to 68 for the head:

```java
GeoBone sheath = model.getBone("cubretodo").orElse(null);
boolean wasHidden = sheath != null && sheath.isHidden();
if (sheath != null) sheath.setHidden(true);

super.actuallyRender(...);

if (sheath != null) sheath.setHidden(wasHidden);
```

The save and restore is safe under re-entrancy, which is reachable here because `GeoRenderer.reRender` dispatches virtually back into `actuallyRender` and a third-party layer can be injected through the `GeoRenderEvent.Item.CompileRenderLayers` event. A nested call captures `true` and restores `true`, while the outermost call restores `false`, so the bone stays hidden for the entire held render and is restored exactly once. This holds because the value written is the constant `true`; it would not hold if the code wrote a computed value.

## Scope

Two commits, one per weapon, so they can be taken separately.

I checked the other `setHidden` call sites in the mod for the same pattern. `BoneVisibilityHandler` line 117 has no same-method restore, but that is correct by design because it is reapplied every frame from `preRender` and the armour layers unhide with their own save and restore. Every other site is either a correct save and restore or a per-frame recompute. The Z Sword, Yajirobe katana and Dimensional Sword models have no `cubretodo` bone, so there is no third case to cover.

No other code in the repository reads `cubretodo`. It appears only in the two geo JSON files and these two renderers.

## Testing

Built and tested in a dev client on 1.20.1. Both weapons now keep their scabbard and holster on the back after being drawn and stowed, and neither renders a scabbard in hand.
