### PR TITLE
Keep the empty scabbard on the back while the weapon is drawn

### DIFF
--- a/src/main/java/com/dragonminez/client/render/layer/DMZRacePartsLayer.java
+++ b/src/main/java/com/dragonminez/client/render/layer/DMZRacePartsLayer.java
@@ -552,33 +552,75 @@ public class DMZRacePartsLayer<T extends AbstractClientPlayer & GeoAnimatable> e
 			}
 		}
 
-		if (stats.getStatus().getBackWeapon() == null || stats.getStatus().getBackWeapon().isEmpty()) return;
+		String backWeapon = stats.getStatus().getBackWeapon();
 
-		if (stats.getStatus().getBackWeapon().equals(MainItems.POWER_POLE.get().getDescriptionId())) {
-			BakedGeoModel powerpole = getGeoModel().getBakedModel(POWER_POLE_MODEL);
-			if (powerpole != null) {
-				RenderType type = RenderType.entityCutoutNoCull(POWER_POLE_TEXTURE);
-				renderWeaponFromBodyAnchor(powerpole, "baculo", playerBodyBone, poseStack, bufferSource, animatable, type, partialTick, packedLight, 1.0f);
+		if (backWeapon == null || backWeapon.isEmpty()) return;
+
+		// backWeapon only names the weapon the player owns. Whether it is in hand right now
+		// is read straight off the entity, which costs no server round trip, so the sheath
+		// never blinks out while a stale value catches up. Held items are synced for every
+		// player, so this is correct for other players too.
+		if (backWeapon.equals(MainItems.POWER_POLE.get().getDescriptionId())) {
+			renderPowerPoleOnBack(poseStack, animatable, playerBodyBone, bufferSource, partialTick, packedLight, isHolding(animatable, MainItems.POWER_POLE.get()));
+		} else if (backWeapon.equals(MainItems.Z_SWORD.get().getDescriptionId())) {
+			// The Z Sword model carries no sheath bone, so it just leaves the back when drawn.
+			if (!isHolding(animatable, MainItems.Z_SWORD.get())) {
+				BakedGeoModel zModel = getGeoModel().getBakedModel(Z_SWORD_MODEL);
+				if (zModel != null) {
+					RenderType type = RenderType.entityCutoutNoCull(Z_SWORD_TEXTURE);
+					renderWeaponFromBodyAnchor(zModel, "espada", playerBodyBone, poseStack, bufferSource, animatable, type, partialTick, packedLight, 1.0f);
+				}
 			}
-		} else if (stats.getStatus().getBackWeapon().equals(MainItems.Z_SWORD.get().getDescriptionId())) {
-			BakedGeoModel zModel = getGeoModel().getBakedModel(Z_SWORD_MODEL);
-			if (zModel != null) {
-				RenderType type = RenderType.entityCutoutNoCull(Z_SWORD_TEXTURE);
-				renderWeaponFromBodyAnchor(zModel, "espada", playerBodyBone, poseStack, bufferSource, animatable, type, partialTick, packedLight, 1.0f);
-			}
-		} else if (stats.getStatus().getBackWeapon().equals(MainItems.BRAVE_SWORD.get().getDescriptionId())) {
-			BakedGeoModel braveModel = getGeoModel().getBakedModel(BRAVE_SWORD_MODEL);
-			if (braveModel != null) {
-				RenderType type = RenderType.entityCutoutNoCull(BRAVE_SWORD_TEXTURE);
-				poseStack.pushPose();
-				poseStack.translate(BRAVE_BACK_X, BRAVE_BACK_Y, BRAVE_BACK_Z);
-				if (BRAVE_BACK_ROT_X != 0.0F) poseStack.mulPose(Axis.XP.rotationDegrees(BRAVE_BACK_ROT_X));
-				if (BRAVE_BACK_ROT_Y != 0.0F) poseStack.mulPose(Axis.YP.rotationDegrees(BRAVE_BACK_ROT_Y));
-                if (BRAVE_BACK_ROT_Z != 0.0F) poseStack.mulPose(Axis.ZP.rotationDegrees(BRAVE_BACK_ROT_Z));
-				renderWeaponFromBodyAnchor(braveModel, "espadatrunks", playerBodyBone, poseStack, bufferSource, animatable, type, partialTick, packedLight, BRAVE_BACK_SCALE);
-				poseStack.popPose();
-			}
+		} else if (backWeapon.equals(MainItems.BRAVE_SWORD.get().getDescriptionId())) {
+			renderBraveSwordOnBack(poseStack, animatable, playerBodyBone, bufferSource, partialTick, packedLight, isHolding(animatable, MainItems.BRAVE_SWORD.get()));
 		}
+	}
+
+	private static boolean isHolding(AbstractClientPlayer player, Item item) {
+		return player.getMainHandItem().is(item) || player.getOffhandItem().is(item);
+	}
+
+	/**
+	 * Renders the Brave Sword on the player's back. With {@code scabbardOnly} the sword
+	 * bone is hidden so only the scabbard draws, which is what stays behind while the
+	 * sword itself is in hand.
+	 */
+	private void renderBraveSwordOnBack(PoseStack poseStack, T animatable, GeoBone playerBodyBone, MultiBufferSource bufferSource, float partialTick, int packedLight, boolean scabbardOnly) {
+		BakedGeoModel braveModel = getGeoModel().getBakedModel(BRAVE_SWORD_MODEL);
+		if (braveModel == null) return;
+
+		GeoBone blade = scabbardOnly ? braveModel.getBone("espada").orElse(null) : null;
+		boolean bladeWasHidden = blade != null && blade.isHidden();
+		if (blade != null) blade.setHidden(true);
+
+		RenderType type = RenderType.entityCutoutNoCull(BRAVE_SWORD_TEXTURE);
+		poseStack.pushPose();
+		poseStack.translate(BRAVE_BACK_X, BRAVE_BACK_Y, BRAVE_BACK_Z);
+		if (BRAVE_BACK_ROT_X != 0.0F) poseStack.mulPose(Axis.XP.rotationDegrees(BRAVE_BACK_ROT_X));
+		if (BRAVE_BACK_ROT_Y != 0.0F) poseStack.mulPose(Axis.YP.rotationDegrees(BRAVE_BACK_ROT_Y));
+		if (BRAVE_BACK_ROT_Z != 0.0F) poseStack.mulPose(Axis.ZP.rotationDegrees(BRAVE_BACK_ROT_Z));
+		renderWeaponFromBodyAnchor(braveModel, "espadatrunks", playerBodyBone, poseStack, bufferSource, animatable, type, partialTick, packedLight, BRAVE_BACK_SCALE);
+		poseStack.popPose();
+
+		if (blade != null) blade.setHidden(bladeWasHidden);
+	}
+
+	/**
+	 * Renders the Power Pole on the player's back. With {@code holsterOnly} the pole bone
+	 * is hidden so only the holster draws.
+	 */
+	private void renderPowerPoleOnBack(PoseStack poseStack, T animatable, GeoBone playerBodyBone, MultiBufferSource bufferSource, float partialTick, int packedLight, boolean holsterOnly) {
+		BakedGeoModel powerpole = getGeoModel().getBakedModel(POWER_POLE_MODEL);
+		if (powerpole == null) return;
+
+		GeoBone pole = holsterOnly ? powerpole.getBone("palo").orElse(null) : null;
+		boolean poleWasHidden = pole != null && pole.isHidden();
+		if (pole != null) pole.setHidden(true);
+
+		RenderType type = RenderType.entityCutoutNoCull(POWER_POLE_TEXTURE);
+		renderWeaponFromBodyAnchor(powerpole, "baculo", playerBodyBone, poseStack, bufferSource, animatable, type, partialTick, packedLight, 1.0f);
+
+		if (pole != null) pole.setHidden(poleWasHidden);
 	}
 
 	private void renderWeaponFromBodyAnchor(BakedGeoModel weaponModel, String anchorBoneName, GeoBone playerBodyBone, PoseStack poseStack, MultiBufferSource bufferSource, T animatable, RenderType type, float partialTick, int packedLight, float scale) {

--- a/src/main/java/com/dragonminez/common/init/item/weapons/render/BraveSwordRenderer.java
+++ b/src/main/java/com/dragonminez/common/init/item/weapons/render/BraveSwordRenderer.java
@@ -9,6 +9,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
+import software.bernie.geckolib.cache.object.GeoBone;
 import software.bernie.geckolib.renderer.GeoItemRenderer;
 
 public class BraveSwordRenderer extends GeoItemRenderer<BraveSwordItem> {
@@ -20,11 +21,17 @@ public class BraveSwordRenderer extends GeoItemRenderer<BraveSwordItem> {
 	@Override
 	public void actuallyRender(PoseStack poseStack, BraveSwordItem animatable, BakedGeoModel model, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
 
-		model.getBone("cubretodo").ifPresent(bone -> {
-			bone.setHidden(true);
-		});
+		// Hide the scabbard while the sword is held, then put it back. BakedGeoModel
+		// instances are cached per model file in GeckoLibCache and shared by every
+		// renderer that uses them, so leaving the bone hidden here also hides it in
+		// DMZRacePartsLayer, which draws the sheathed sword on the player's back.
+		GeoBone sheath = model.getBone("cubretodo").orElse(null);
+		boolean wasHidden = sheath != null && sheath.isHidden();
+		if (sheath != null) sheath.setHidden(true);
 
 		super.actuallyRender(poseStack, animatable, model, renderType, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, red, green, blue, alpha);
+
+		if (sheath != null) sheath.setHidden(wasHidden);
 
 	}
 

--- a/src/main/java/com/dragonminez/common/init/item/weapons/render/PowerPoleRenderer.java
+++ b/src/main/java/com/dragonminez/common/init/item/weapons/render/PowerPoleRenderer.java
@@ -9,6 +9,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
+import software.bernie.geckolib.cache.object.GeoBone;
 import software.bernie.geckolib.renderer.GeoItemRenderer;
 
 public class PowerPoleRenderer extends GeoItemRenderer<PowerPoleItem> {
@@ -20,11 +21,17 @@ public class PowerPoleRenderer extends GeoItemRenderer<PowerPoleItem> {
 	@Override
 	public void actuallyRender(PoseStack poseStack, PowerPoleItem animatable, BakedGeoModel model, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
 
-		model.getBone("cubretodo").ifPresent(bone -> {
-			bone.setHidden(true);
-		});
+		// Hide the holster while the pole is held, then put it back. BakedGeoModel
+		// instances are cached per model file in GeckoLibCache and shared by every
+		// renderer that uses them, so leaving the bone hidden here also hides it in
+		// DMZRacePartsLayer, which draws the stowed pole on the player's back.
+		GeoBone holster = model.getBone("cubretodo").orElse(null);
+		boolean wasHidden = holster != null && holster.isHidden();
+		if (holster != null) holster.setHidden(true);
 
 		super.actuallyRender(poseStack, animatable, model, renderType, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, red, green, blue, alpha);
+
+		if (holster != null) holster.setHidden(wasHidden);
 
 	}
 

--- a/src/main/java/com/dragonminez/server/events/players/TickHandler.java
+++ b/src/main/java/com/dragonminez/server/events/players/TickHandler.java
@@ -344,8 +344,14 @@ public class TickHandler {
 					data.getStatus().setRenderKatana(renderKatanaTarget);
 				}
 
-				ItemStack backItem = ItemStack.EMPTY;
-				boolean holdingOtherWeapon = false;
+				// backWeapon names the weapon the player OWNS, whether it is in hand or not, so
+				// it does not change when the weapon is merely drawn or stowed. That matters:
+				// this block runs only every 5 ticks and then still has to reach the client, so
+				// a field that flipped on every draw would leave the client disagreeing for up
+				// to 500ms with the hand it can already see, and the sheath would blink out.
+				// The client derives drawn state from the held item instead, which is instant.
+				ItemStack heldWeapon = ItemStack.EMPTY;
+				ItemStack stowedWeapon = ItemStack.EMPTY;
 				for (int i = 0; i < serverPlayer.getInventory().getContainerSize(); i++) {
 					ItemStack stack = serverPlayer.getInventory().getItem(i);
 					if (stack.isEmpty()) continue;
@@ -353,24 +359,47 @@ public class TickHandler {
 
 					if (item == MainItems.Z_SWORD.get() || item == MainItems.BRAVE_SWORD.get() || item == MainItems.POWER_POLE.get()) {
 						boolean isHeld = serverPlayer.getMainHandItem().getItem() == item || serverPlayer.getOffhandItem().getItem() == item;
-						if (isHeld) holdingOtherWeapon = true;
-						else if (backItem == ItemStack.EMPTY) backItem = item.getDefaultInstance();
+						if (isHeld) {
+							if (heldWeapon == ItemStack.EMPTY) heldWeapon = item.getDefaultInstance();
+						} else if (stowedWeapon == ItemStack.EMPTY) {
+							stowedWeapon = item.getDefaultInstance();
+						}
 					}
 				}
+
+				// A held weapon takes the slot, because its sheath is the one that should stay
+				// on the back. The Z Sword is the exception: it has no sheath bone and renders
+				// nothing while held, so letting it claim the slot would blank the back and
+				// hide a weapon that is genuinely stowed there.
+				boolean heldHasSheath = heldWeapon != ItemStack.EMPTY && heldWeapon.getItem() != MainItems.Z_SWORD.get();
+				ItemStack backItem;
+				if (heldHasSheath) backItem = heldWeapon;
+				else if (stowedWeapon != ItemStack.EMPTY) backItem = stowedWeapon;
+				else backItem = heldWeapon;
+
+				boolean weaponDrawn = heldWeapon != ItemStack.EMPTY;
 
 				String newBackWeapon = backItem != ItemStack.EMPTY ? backItem.getDescriptionId() : "";
 				String currentBackWeapon = data.getStatus().getBackWeapon();
+				// Edge detection only, never read by the client, so it stays out of StatsData and
+				// its save contract. Same idiom as dmz_ki_anim_active further up this method.
+				boolean wasDrawn = serverPlayer.getPersistentData().getBoolean("dmz_weapon_drawn");
 
-				if (!currentBackWeapon.equals(newBackWeapon)) {
-					if (!playedSound) {
-						if (!newBackWeapon.isEmpty()) {
-							serverPlayer.level().playSound(null, serverPlayer.blockPosition(), MainSounds.SWORD_IN.get(), SoundSource.PLAYERS, 1.0F, 1.0F);
-						} else if (holdingOtherWeapon) {
-							serverPlayer.level().playSound(null, serverPlayer.blockPosition(), MainSounds.SWORD_OUT.get(), SoundSource.PLAYERS, 1.0F, 1.0F);
-						}
+				if (!playedSound) {
+					if (weaponDrawn && !wasDrawn) {
+						serverPlayer.level().playSound(null, serverPlayer.blockPosition(), MainSounds.SWORD_OUT.get(), SoundSource.PLAYERS, 1.0F, 1.0F);
+					} else if (!weaponDrawn && wasDrawn && !newBackWeapon.isEmpty()) {
+						// Only when it is still owned. Dying with a drawn weapon, dropping it or
+						// clearing it is not sheathing it, and must not play the sheathing sound.
+						serverPlayer.level().playSound(null, serverPlayer.blockPosition(), MainSounds.SWORD_IN.get(), SoundSource.PLAYERS, 1.0F, 1.0F);
+					} else if (currentBackWeapon.isEmpty() && !newBackWeapon.isEmpty() && !weaponDrawn) {
+						// Newly acquired and it went straight onto the back.
+						serverPlayer.level().playSound(null, serverPlayer.blockPosition(), MainSounds.SWORD_IN.get(), SoundSource.PLAYERS, 1.0F, 1.0F);
 					}
-					data.getStatus().setBackWeapon(newBackWeapon);
 				}
+
+				if (weaponDrawn != wasDrawn) serverPlayer.getPersistentData().putBoolean("dmz_weapon_drawn", weaponDrawn);
+				if (!currentBackWeapon.equals(newBackWeapon)) data.getStatus().setBackWeapon(newBackWeapon);
 
 				ItemStack headTechStack = CuriosUtil.getFirstStack(serverPlayer, "head_tech");
 				String itemId = headTechStack.getDescriptionId();


### PR DESCRIPTION
> **Depends on #263 and must merge after it.** Without that fix the item renderer leaves the scabbard bone hidden on the shared cached model, so with the sword bone also hidden here, nothing renders on the back at all.

## Summary

Drawing the Brave Sword or the Power Pole currently removes the whole rig from the player's back. This keeps the empty scabbard or holster there, so only the weapon itself moves to the hand.

The models already support it. In `brave_sword.geo.json` the anchor `espadatrunks` parents `cubretodo` (the scabbard) and `espada` (the complete sword, hilt included) as independent siblings, so the back render can draw one without the other. `power_pole.geo.json` has the same shape with `baculo`, `cubretodo` and `palo`.

## Demo

<!-- VIDEO GOES HERE -->

## How drawn state is decided

The client reads the held item straight off the player rather than waiting for server state:

```java
private static boolean isHolding(AbstractClientPlayer player, Item item) {
    return player.getMainHandItem().is(item) || player.getOffhandItem().is(item);
}
```

Both hands sync to every client for every player, since `LivingEntity.detectEquipmentUpdates` runs unconditionally each tick and reports emptied slots as changes too. So this is correct for other players and not only the local one, and it costs no round trip.

## Why `backWeapon` changed meaning

`backWeapon` used to be cleared whenever the weapon was in hand, so it flipped on every draw and stow. It is computed on a 5-tick cycle in `TickHandler` and synced on a 10-tick one, so there was a window of up to 500ms in which the client disagreed with the hand it could already see.

Stowing landed in the bad half of that window: `backWeapon` was still empty while the player was no longer holding anything, so neither branch drew and the sheath blinked out. Drawing hit the mirror case, briefly rendering the sword both on the back and in hand.

`backWeapon` now names the weapon the player owns, held or not, so for a player carrying one of these weapons it does not change on draw or stow at all and there is nothing to wait for.

A held weapon takes the slot over a stowed one, since its sheath is the one that should stay on the back. **The Z Sword is excluded from that preference**: it has no sheath bone and renders nothing while held, so letting it claim the slot would blank the back and hide a weapon that is genuinely stowed there.

## Sheathing sounds

`SWORD_IN` and `SWORD_OUT` previously keyed off the `backWeapon` transition, which no longer happens on draw and stow, so they now key off the drawn transition instead.

That edge is tracked with `getPersistentData()` rather than a new field on `StatsData`, matching the `dmz_ki_anim_active` idiom already used elsewhere in the same method. Nothing is added to the save contract and no client reads it.

The sheathing sound only plays if the weapon is still owned afterwards. Losing a held weapon by dying, dropping it or clearing it is not sheathing it and is silent.

## Bone visibility is restored, not left hidden

The scabbard-only render hides `espada` (or `palo`) and restores the previous value afterwards, the same discipline #263 introduces:

```java
GeoBone blade = scabbardOnly ? braveModel.getBone("espada").orElse(null) : null;
boolean bladeWasHidden = blade != null && blade.isHidden();
if (blade != null) blade.setHidden(true);
...
if (blade != null) blade.setHidden(bladeWasHidden);
```

This cannot make the held sword disappear. `renderWeaponFromBodyAnchor` passes `isReRender = true`, and `GeoEntityRenderer.renderRecursively` skips layer application when that is set, so the scabbard render re-enters no layer. The held item is drawn by a different layer at the grip bones, and per-bone layer invocation is sequential rather than nested.

## Known limitations

`backWeapon` is a single slot, so a player who owns more than one of the Z Sword, Brave Sword and Power Pole only ever has one rig on their back. Two consequences worth stating plainly:

- The stated invariant, that `backWeapon` does not change on draw or stow, holds for a player carrying one of these weapons. Carrying two, the stowed candidate is chosen by lowest inventory slot, so stowing one weapon can hand the slot to the other and the rig on the back will change up to 500ms later.
- Holding one weapon shows that weapon's sheath on the back, and the other is not shown.

Both are pre-existing consequences of the single-slot field rather than something this change introduces, and neither is something it tries to solve.

## Testing

Tested in a dev client on 1.20.1:

- Brave Sword and Power Pole each draw and stow with the sheath staying in place, no flicker in either direction.
- Carrying both weapons at once and drawing one gives that weapon's sheath on the back.
- Holding the Z Sword with a Brave Sword stowed still shows the Brave Sword on the back.
- Dying while holding a drawn weapon plays no sheathing sound.
- Sheathing sounds still fire on draw and stow.
- Off hand behaves the same as main hand.
