### PR TITLE
fix: support custom Dragon Ball sets and wishes

### DIFF
--- a/src/main/java/com/dragonminez/common/dragonball/DragonBallSetMatcher.java
+++ b/src/main/java/com/dragonminez/common/dragonball/DragonBallSetMatcher.java
@@ -1,0 +1,18 @@
+package com.dragonminez.common.dragonball;
+
+import java.util.Set;
+
+/**
+ * Pure matching rules for deciding whether a dragon ball set is complete.
+ */
+public final class DragonBallSetMatcher {
+    private DragonBallSetMatcher() {
+    }
+
+    public static boolean containsAllRequiredStars(Set<Integer> requiredStars, Set<Integer> foundStars) {
+        return requiredStars != null
+                && !requiredStars.isEmpty()
+                && foundStars != null
+                && foundStars.containsAll(requiredStars);
+    }
+}

--- a/src/main/java/com/dragonminez/common/init/block/custom/DragonBallBlock.java
+++ b/src/main/java/com/dragonminez/common/init/block/custom/DragonBallBlock.java
@@ -1,7 +1,9 @@
 package com.dragonminez.common.init.block.custom;
 
+import com.dragonminez.Reference;
 import com.dragonminez.common.dragonball.DragonBallDefinitions;
 import com.dragonminez.common.dragonball.DragonBallSetDefinition;
+import com.dragonminez.common.dragonball.DragonBallSetMatcher;
 import com.dragonminez.common.dragonball.DragonDefinition;
 import com.dragonminez.common.events.DMZEvent;
 import com.dragonminez.common.init.MainSounds;
@@ -127,21 +129,24 @@ public class DragonBallBlock extends BaseEntityBlock implements EntityBlock {
 		}
 
 		if (areAllDragonBallsNearby(level, pos, ballSetDefinition)) {
-			List<BlockPos> consumedPositions = removeAllDragonBalls(level, pos, ballSetDefinition);
-			if (level instanceof ServerLevel serverLevel) {
-				DragonBallsHandler.unregisterConsumedDragonBalls(serverLevel, consumedPositions, ballSetId);
-				if (summonDragon(serverLevel, pos, player, dragonDefinition)) {
-					MinecraftForge.EVENT_BUS.post(new DMZEvent.DragonSummonedEvent(
-							player,
-							serverLevel,
-							pos,
-							dragonDefinition,
-							ballSetDefinition,
-							consumedPositions
-					));
-					serverLevel.playSound(null, pos, MainSounds.SHENRON.get(), SoundSource.AMBIENT, 1.0F, 1.0F);
-				}
+			if (!(level instanceof ServerLevel serverLevel)) {
+				return InteractionResult.PASS;
 			}
+			if (!summonDragon(serverLevel, pos, player, dragonDefinition)) {
+				return InteractionResult.PASS;
+			}
+
+			List<BlockPos> consumedPositions = removeAllDragonBalls(level, pos, ballSetDefinition);
+			DragonBallsHandler.unregisterConsumedDragonBalls(serverLevel, consumedPositions, ballSetId);
+			MinecraftForge.EVENT_BUS.post(new DMZEvent.DragonSummonedEvent(
+					player,
+					serverLevel,
+					pos,
+					dragonDefinition,
+					ballSetDefinition,
+					consumedPositions
+			));
+			serverLevel.playSound(null, pos, MainSounds.SHENRON.get(), SoundSource.AMBIENT, 1.0F, 1.0F);
 			return InteractionResult.CONSUME;
 		}
 
@@ -149,7 +154,12 @@ public class DragonBallBlock extends BaseEntityBlock implements EntityBlock {
 	}
 
 	private boolean summonDragon(ServerLevel serverLevel, BlockPos pos, Player player, DragonDefinition dragonDefinition) {
-		EntityType<?> entityType = ForgeRegistries.ENTITY_TYPES.getValue(ResourceLocation.fromNamespaceAndPath("dragonminez", dragonDefinition.getId()));
+		ResourceLocation entityLocation = resolveEntityLocation(dragonDefinition.getEntityRegistryName());
+		if (entityLocation == null) {
+			return false;
+		}
+
+		EntityType<?> entityType = ForgeRegistries.ENTITY_TYPES.getValue(entityLocation);
 		if (entityType == null) {
 			return false;
 		}
@@ -167,16 +177,29 @@ public class DragonBallBlock extends BaseEntityBlock implements EntityBlock {
 		return serverLevel.addFreshEntity(dragon);
 	}
 
+	private static ResourceLocation resolveEntityLocation(String entityRegistryName) {
+		if (entityRegistryName == null || entityRegistryName.isBlank()) {
+			return null;
+		}
+		try {
+			return entityRegistryName.indexOf(':') >= 0
+					? ResourceLocation.parse(entityRegistryName)
+					: ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, entityRegistryName);
+		} catch (IllegalArgumentException exception) {
+			return null;
+		}
+	}
+
 	private boolean areAllDragonBallsNearby(Level level, BlockPos pos, DragonBallSetDefinition setDefinition) {
-		Set<DragonBallType> foundBalls = new HashSet<>();
+		Set<Integer> foundStars = new HashSet<>();
 		int radius = setDefinition.getSummonRadius();
 		for (BlockPos checkPos : BlockPos.betweenClosed(pos.offset(-radius, -radius, -radius), pos.offset(radius, radius, radius))) {
 			Block block = level.getBlockState(checkPos).getBlock();
 			if (block instanceof DragonBallBlock dragonBall && ballSetId.equals(dragonBall.getBallSetId())) {
-				foundBalls.add(dragonBall.getBallType());
+				foundStars.add(dragonBall.getBallType().getStars());
 			}
 		}
-		return foundBalls.size() == 7;
+		return DragonBallSetMatcher.containsAllRequiredStars(setDefinition.getStars(), foundStars);
 	}
 
 	private List<BlockPos> removeAllDragonBalls(Level level, BlockPos pos, DragonBallSetDefinition setDefinition) {

--- a/src/main/java/com/dragonminez/common/init/block/custom/DragonBallBlock.java
+++ b/src/main/java/com/dragonminez/common/init/block/custom/DragonBallBlock.java
@@ -11,6 +11,7 @@ import com.dragonminez.common.init.block.entity.DragonBallBlockEntity;
 import com.dragonminez.server.events.DragonBallsHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.ResourceLocationException;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundSource;
@@ -185,7 +186,7 @@ public class DragonBallBlock extends BaseEntityBlock implements EntityBlock {
 			return entityRegistryName.indexOf(':') >= 0
 					? ResourceLocation.parse(entityRegistryName)
 					: ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, entityRegistryName);
-		} catch (IllegalArgumentException exception) {
+		} catch (IllegalArgumentException | ResourceLocationException exception) {
 			return null;
 		}
 	}

--- a/src/main/java/com/dragonminez/common/util/ItemIdAliases.java
+++ b/src/main/java/com/dragonminez/common/util/ItemIdAliases.java
@@ -1,0 +1,16 @@
+package com.dragonminez.common.util;
+
+/**
+ * Stable aliases for item IDs that were written to persistent wish files by older releases.
+ */
+public final class ItemIdAliases {
+    public static final String LEGACY_SENZU_ID = "dragonminez:senzu";
+    public static final String SENZU_BEAN_ID = "dragonminez:senzu_bean";
+
+    private ItemIdAliases() {
+    }
+
+    public static String normalize(String itemId) {
+        return LEGACY_SENZU_ID.equals(itemId) ? SENZU_BEAN_ID : itemId;
+    }
+}

--- a/src/main/java/com/dragonminez/common/util/adapters/WishTypeAdapter.java
+++ b/src/main/java/com/dragonminez/common/util/adapters/WishTypeAdapter.java
@@ -23,6 +23,9 @@ public class WishTypeAdapter implements JsonSerializer<Wish>, JsonDeserializer<W
 		if (target == null) {
 			throw new JsonParseException("Unknown wish type: " + type);
 		}
+		if (target == MultiItemWish.class) {
+			return MultiItemWish.fromJson(jsonObject);
+		}
 		return new GsonBuilder().create().fromJson(json, target);
 	}
 

--- a/src/main/java/com/dragonminez/common/util/types/items/GenericItemDTO.java
+++ b/src/main/java/com/dragonminez/common/util/types/items/GenericItemDTO.java
@@ -1,5 +1,6 @@
 package com.dragonminez.common.util.types.items;
 
+import com.dragonminez.common.util.ItemIdAliases;
 import com.google.gson.GsonBuilder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,7 +30,7 @@ public class GenericItemDTO {
     }
 
     public ItemStack getItemStack() {
-        var item = ForgeRegistries.ITEMS.getValue(ResourceLocation.parse(this.getItemId()));
+        var item = ForgeRegistries.ITEMS.getValue(ResourceLocation.parse(ItemIdAliases.normalize(this.getItemId())));
         if (item != null) {
             return new ItemStack(item, this.count);
         }

--- a/src/main/java/com/dragonminez/common/wish/DragonWishRegistry.java
+++ b/src/main/java/com/dragonminez/common/wish/DragonWishRegistry.java
@@ -5,6 +5,7 @@ import com.dragonminez.LogUtil;
 import com.dragonminez.Reference;
 import com.dragonminez.common.dragonball.DragonBallDefinitions;
 import com.dragonminez.common.dragonball.DragonBallPackManager;
+import com.dragonminez.common.dragonball.DragonDefinition;
 import com.dragonminez.common.network.NetworkHandler;
 import com.dragonminez.common.network.S2C.SyncWishesS2C;
 import com.dragonminez.common.util.adapters.GenericItemTypeAdapter;
@@ -52,13 +53,32 @@ public class DragonWishRegistry extends SimpleJsonResourceReloadListener {
 		DragonBallPackManager.LoadedDefinitions external = DragonBallPackManager.loadAll();
 		Map<String, List<Wish>> loaded = new LinkedHashMap<>(external.wishes);
 		for (var dragon : DragonBallDefinitions.getDragons()) loaded.putIfAbsent(dragon.getId(), List.of());
-		serverWishes = Map.copyOf(loaded);
+		serverWishes = withWishScreenAliases(loaded);
 		LogUtil.info(Env.COMMON, "Loaded {} dragon wish list(s) from the dragonballs system", serverWishes.size());
 	}
 
-	public static void setServerWishes(Map<String, List<Wish>> wishes) { serverWishes = Map.copyOf(wishes); }
+	public static void setServerWishes(Map<String, List<Wish>> wishes) { serverWishes = withWishScreenAliases(wishes); }
 	@OnlyIn(Dist.CLIENT) public static Map<String, List<Wish>> getClientWishes() { return clientWishes; }
-	@OnlyIn(Dist.CLIENT) public static void setClientWishes(Map<String, List<Wish>> wishes) { clientWishes = Map.copyOf(wishes); }
+	@OnlyIn(Dist.CLIENT) public static void setClientWishes(Map<String, List<Wish>> wishes) { clientWishes = withWishScreenAliases(wishes); }
+
+	/**
+	 * Pack files are keyed by the dragon definition ID, while the UI and grant packet use
+	 * {@code wish_screen_id}. Keep both keys available so custom dragons can reuse a screen
+	 * without losing the wish list loaded from their own definition file. If multiple dragons
+	 * share a screen ID, the first canonical screen entry wins deterministically.
+	 */
+	private static Map<String, List<Wish>> withWishScreenAliases(Map<String, List<Wish>> wishes) {
+		Map<String, List<Wish>> byDragonId = new LinkedHashMap<>(wishes);
+		Map<String, List<Wish>> aliased = new LinkedHashMap<>(byDragonId);
+		for (DragonDefinition dragon : DragonBallDefinitions.getDragons()) {
+			String wishScreenId = dragon.getWishScreenId();
+			List<Wish> dragonWishes = byDragonId.get(dragon.getId());
+			if (wishScreenId != null && !wishScreenId.isBlank() && dragonWishes != null) {
+				aliased.putIfAbsent(wishScreenId, dragonWishes);
+			}
+		}
+		return Map.copyOf(aliased);
+	}
 
 	@SubscribeEvent
 	public static void onDatapackSync(OnDatapackSyncEvent event) {

--- a/src/main/java/com/dragonminez/common/wish/WishManager.java
+++ b/src/main/java/com/dragonminez/common/wish/WishManager.java
@@ -111,27 +111,17 @@ public class WishManager {
 		File wishFile = wishDir.resolve("shenron.json").toFile();
 		List<Wish> defaultWishes = new ArrayList<>();
 
-		List<GenericItemDTO> senzu = new ArrayList<>();
-		senzu.add(new GenericItemDTO("dragonminez:senzu_bean", 16));
-		defaultWishes.add(new ItemListWish("wish.shenron.senzu.name", "wish.shenron.senzu.desc", senzu));
+		defaultWishes.add(new ItemWish("wish.shenron.senzu.name", "wish.shenron.senzu.desc", "dragonminez:senzu_bean", 16));
 
 		defaultWishes.add(new TPSWish("wish.shenron.tps.name", "wish.shenron.tps.desc", 5000));
 
-		List<GenericItemDTO> powerPole = new ArrayList<>();
-		powerPole.add(new GenericItemDTO("dragonminez:power_pole", 1));
-		defaultWishes.add(new ItemListWish("wish.shenron.powerpole.name", "wish.shenron.powerpole.desc", powerPole));
+		defaultWishes.add(new ItemWish("wish.shenron.powerpole.name", "wish.shenron.powerpole.desc", "dragonminez:power_pole", 1));
 
-		List<GenericItemDTO> mightFruit = new ArrayList<>();
-		mightFruit.add(new GenericItemDTO("dragonminez:might_tree_fruit", 16));
-		defaultWishes.add(new ItemListWish("wish.shenron.mightfruit.name", "wish.shenron.mightfruit.desc", mightFruit));
+		defaultWishes.add(new ItemWish("wish.shenron.mightfruit.name", "wish.shenron.mightfruit.desc", "dragonminez:might_tree_fruit", 16));
 
-		List<GenericItemDTO> namekCpu = new ArrayList<>();
-		namekCpu.add(new GenericItemDTO("dragonminez:t2_radar_cpu", 4));
-		defaultWishes.add(new ItemListWish("wish.shenron.namekcpu.name", "wish.shenron.namekcpu.desc", namekCpu));
+		defaultWishes.add(new ItemWish("wish.shenron.namekcpu.name", "wish.shenron.namekcpu.desc", "dragonminez:t2_radar_cpu", 4));
 
-		List<GenericItemDTO> saiyanShip = new ArrayList<>();
-		saiyanShip.add(new GenericItemDTO("dragonminez:saiyan_ship", 1));
-		defaultWishes.add(new ItemListWish("wish.shenron.saiyanship.name", "wish.shenron.saiyanship.desc", saiyanShip));
+		defaultWishes.add(new ItemWish("wish.shenron.saiyanship.name", "wish.shenron.saiyanship.desc", "dragonminez:saiyan_ship", 1));
 
 		defaultWishes.add(new PassiveResetWish("wish.shenron.racialskillreset.name", "wish.shenron.racialskillreset.desc"));
 		defaultWishes.add(new ReCustomizeWish("wish.shenron.customization.name", "wish.shenron.customization.desc"));
@@ -163,15 +153,11 @@ public class WishManager {
 		File wishFile = wishDir.resolve("porunga.json").toFile();
 		List<Wish> defaultWishes = new ArrayList<>();
 
-		List<GenericItemDTO> senzu = new ArrayList<>();
-		senzu.add(new GenericItemDTO("dragonminez:senzu_bean", 32));
-		defaultWishes.add(new ItemListWish("wish.porunga.senzu.name", "wish.porunga.senzu.desc", senzu));
+		defaultWishes.add(new ItemWish("wish.porunga.senzu.name", "wish.porunga.senzu.desc", "dragonminez:senzu_bean", 32));
 
 		defaultWishes.add(new TPSWish("wish.porunga.tps.name", "wish.porunga.tps.desc", 15000));
 
-		List<GenericItemDTO> braveSword = new ArrayList<>();
-		braveSword.add(new GenericItemDTO("dragonminez:brave_sword", 1));
-		defaultWishes.add(new ItemListWish("wish.porunga.bravesword.name", "wish.porunga.bravesword.desc",  braveSword));
+		defaultWishes.add(new ItemWish("wish.porunga.bravesword.name", "wish.porunga.bravesword.desc", "dragonminez:brave_sword", 1));
 
 		defaultWishes.add(new PassiveResetWish("wish.porunga.racialskillreset.name", "wish.porunga.racialskillreset.desc"));
 		defaultWishes.add(new ReCustomizeWish("wish.porunga.customization.name", "wish.porunga.customization.desc"));

--- a/src/main/java/com/dragonminez/common/wish/wishes/ItemWish.java
+++ b/src/main/java/com/dragonminez/common/wish/wishes/ItemWish.java
@@ -2,6 +2,7 @@ package com.dragonminez.common.wish.wishes;
 
 import com.dragonminez.Env;
 import com.dragonminez.LogUtil;
+import com.dragonminez.common.util.ItemIdAliases;
 import com.dragonminez.common.wish.Wish;
 import com.google.gson.GsonBuilder;
 import net.minecraft.resources.ResourceLocation;
@@ -23,7 +24,7 @@ public class ItemWish extends Wish {
 
 	@Override
 	public void grant(ServerPlayer player) {
-		Item item = ForgeRegistries.ITEMS.getValue(ResourceLocation.parse(itemId));
+		Item item = ForgeRegistries.ITEMS.getValue(ResourceLocation.parse(ItemIdAliases.normalize(itemId)));
 		if (item != null) {
 			giveOrDrop(player, new ItemStack(item, count));
 		} else {

--- a/src/main/java/com/dragonminez/common/wish/wishes/MultiItemWish.java
+++ b/src/main/java/com/dragonminez/common/wish/wishes/MultiItemWish.java
@@ -48,12 +48,16 @@ public class MultiItemWish extends Wish {
 			JsonObject item = rawItem.getAsJsonObject();
 			String itemId = firstString(item, "itemId", "item_id", "a", "f_14413_");
 			Integer count = firstInt(item, "count", "amount", "b", "f_14414_");
-			if (itemId == null || count == null || count <= 0) {
+			if (itemId == null || itemId.isBlank() || !isValidItemId(itemId) || count == null || count <= 0) {
 				throw new JsonParseException("multi_wish item requires an item ID and a positive count");
 			}
 			items.add(new Tuple<>(itemId, count));
 		}
 		return new MultiItemWish(name, description, items);
+	}
+
+	private static boolean isValidItemId(String itemId) {
+		return ResourceLocation.isValidResourceLocation(ItemIdAliases.normalize(itemId));
 	}
 
 	private static String requiredString(JsonObject root, String key) {
@@ -73,7 +77,13 @@ public class MultiItemWish extends Wish {
 	private static Integer firstInt(JsonObject object, String... keys) {
 		for (String key : keys) {
 			JsonElement value = object.get(key);
-			if (value != null && !value.isJsonNull() && value.isJsonPrimitive()) return value.getAsInt();
+			if (value != null && !value.isJsonNull() && value.isJsonPrimitive()) {
+				try {
+					return value.getAsInt();
+				} catch (RuntimeException exception) {
+					throw new JsonParseException("multi_wish item count must be an integer", exception);
+				}
+			}
 		}
 		return null;
 	}

--- a/src/main/java/com/dragonminez/common/wish/wishes/MultiItemWish.java
+++ b/src/main/java/com/dragonminez/common/wish/wishes/MultiItemWish.java
@@ -2,8 +2,12 @@ package com.dragonminez.common.wish.wishes;
 
 import com.dragonminez.Env;
 import com.dragonminez.LogUtil;
+import com.dragonminez.common.util.ItemIdAliases;
 import com.dragonminez.common.wish.Wish;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Tuple;
@@ -12,6 +16,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.registries.ForgeRegistries;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class MultiItemWish extends Wish {
@@ -22,14 +27,66 @@ public class MultiItemWish extends Wish {
 		this.items = items;
 	}
 
+	/**
+	 * Reads the pre-GenericItemDTO format used by existing custom packs. The pair fields are
+	 * called {@code a}/{@code b} in named mappings, while runtime-generated files can expose
+	 * their mapped names. Accept the newer itemId/count spelling too.
+	 */
+	public static MultiItemWish fromJson(JsonObject root) {
+		String name = requiredString(root, "name");
+		String description = requiredString(root, "description");
+		JsonElement rawItems = root.get("items");
+		if (rawItems == null || !rawItems.isJsonArray()) {
+			throw new JsonParseException("multi_wish requires an items array");
+		}
+
+		List<Tuple<String, Integer>> items = new ArrayList<>();
+		for (JsonElement rawItem : rawItems.getAsJsonArray()) {
+			if (!rawItem.isJsonObject()) {
+				throw new JsonParseException("multi_wish items must be objects");
+			}
+			JsonObject item = rawItem.getAsJsonObject();
+			String itemId = firstString(item, "itemId", "item_id", "a", "f_14413_");
+			Integer count = firstInt(item, "count", "amount", "b", "f_14414_");
+			if (itemId == null || count == null || count <= 0) {
+				throw new JsonParseException("multi_wish item requires an item ID and a positive count");
+			}
+			items.add(new Tuple<>(itemId, count));
+		}
+		return new MultiItemWish(name, description, items);
+	}
+
+	private static String requiredString(JsonObject root, String key) {
+		String value = firstString(root, key);
+		if (value == null) throw new JsonParseException("multi_wish requires '" + key + "'");
+		return value;
+	}
+
+	private static String firstString(JsonObject object, String... keys) {
+		for (String key : keys) {
+			JsonElement value = object.get(key);
+			if (value != null && !value.isJsonNull() && value.isJsonPrimitive()) return value.getAsString();
+		}
+		return null;
+	}
+
+	private static Integer firstInt(JsonObject object, String... keys) {
+		for (String key : keys) {
+			JsonElement value = object.get(key);
+			if (value != null && !value.isJsonNull() && value.isJsonPrimitive()) return value.getAsInt();
+		}
+		return null;
+	}
+
 	@Override
 	public void grant(ServerPlayer player) {
 		for (Tuple<String, Integer> itemInfo : items) {
-			Item item = ForgeRegistries.ITEMS.getValue(ResourceLocation.parse(itemInfo.getA()));
+			String itemId = ItemIdAliases.normalize(itemInfo.getA());
+			Item item = ForgeRegistries.ITEMS.getValue(ResourceLocation.parse(itemId));
 			if (item != null) {
 				giveOrDrop(player, new ItemStack(item, itemInfo.getB()));
 			} else {
-				LogUtil.warn(Env.COMMON, "Item with id " + itemInfo.getA() + " not found.");
+				LogUtil.warn(Env.COMMON, "Item with id " + itemId + " not found.");
 			}
 		}
 	}

--- a/src/test/java/com/dragonminez/common/dragonball/DragonBallSetMatcherTest.java
+++ b/src/test/java/com/dragonminez/common/dragonball/DragonBallSetMatcherTest.java
@@ -1,0 +1,25 @@
+package com.dragonminez.common.dragonball;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DragonBallSetMatcherTest {
+    @Test
+    void acceptsASetWithFewerThanSevenDeclaredStarsWhenAllArePresent() {
+        assertTrue(DragonBallSetMatcher.containsAllRequiredStars(Set.of(1, 2, 3), Set.of(1, 2, 3)));
+    }
+
+    @Test
+    void rejectsASetWhenOneDeclaredStarIsMissing() {
+        assertFalse(DragonBallSetMatcher.containsAllRequiredStars(Set.of(1, 2, 3), Set.of(1, 2)));
+    }
+
+    @Test
+    void rejectsAnEmptyDefinition() {
+        assertFalse(DragonBallSetMatcher.containsAllRequiredStars(Set.of(), Set.of(1, 2, 3)));
+    }
+}

--- a/src/test/java/com/dragonminez/common/util/ItemIdAliasesTest.java
+++ b/src/test/java/com/dragonminez/common/util/ItemIdAliasesTest.java
@@ -1,0 +1,21 @@
+package com.dragonminez.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ItemIdAliasesTest {
+    @Test
+    void migratesTheLegacySenzuItemId() {
+        assertEquals(ItemIdAliases.SENZU_BEAN_ID, ItemIdAliases.normalize(ItemIdAliases.LEGACY_SENZU_ID));
+    }
+
+    @Test
+    void leavesCurrentAndCustomItemIdsUntouched() {
+        String currentId = ItemIdAliases.SENZU_BEAN_ID;
+        String customId = "example:custom_item";
+
+        assertEquals(currentId, ItemIdAliases.normalize(currentId));
+        assertEquals(customId, ItemIdAliases.normalize(customId));
+    }
+}

--- a/src/test/java/com/dragonminez/common/wish/wishes/MultiItemWishCompatibilityTest.java
+++ b/src/test/java/com/dragonminez/common/wish/wishes/MultiItemWishCompatibilityTest.java
@@ -1,0 +1,19 @@
+package com.dragonminez.common.wish.wishes;
+
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MultiItemWishCompatibilityTest {
+    @Test
+    void acceptsLegacyTupleKeysUsedByCustomWishFiles() {
+        String json = "{\"type\":\"multi_wish\",\"name\":\"n\",\"description\":\"d\",\"items\":["
+                + "{\"a\":\"minecraft:iron_ingot\",\"b\":64},"
+                + "{\"itemId\":\"minecraft:gold_ingot\",\"count\":2}]}";
+
+        MultiItemWish wish = MultiItemWish.fromJson(JsonParser.parseString(json).getAsJsonObject());
+
+        assertEquals(2, JsonParser.parseString(wish.toJson()).getAsJsonObject().getAsJsonArray("items").size());
+    }
+}

--- a/src/test/java/com/dragonminez/common/wish/wishes/MultiItemWishCompatibilityTest.java
+++ b/src/test/java/com/dragonminez/common/wish/wishes/MultiItemWishCompatibilityTest.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MultiItemWishCompatibilityTest {
     @Test
@@ -15,5 +16,14 @@ class MultiItemWishCompatibilityTest {
         MultiItemWish wish = MultiItemWish.fromJson(JsonParser.parseString(json).getAsJsonObject());
 
         assertEquals(2, JsonParser.parseString(wish.toJson()).getAsJsonObject().getAsJsonArray("items").size());
+    }
+
+    @Test
+    void rejectsInvalidItemIdsDuringParsing() {
+        String json = "{\"type\":\"multi_wish\",\"name\":\"n\",\"description\":\"d\",\"items\":["
+                + "{\"itemId\":\"\",\"count\":1}]}";
+
+        assertThrows(com.google.gson.JsonParseException.class,
+                () -> MultiItemWish.fromJson(JsonParser.parseString(json).getAsJsonObject()));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #268 and #160.

- Fixes Namek Senzu wishes, including worlds with legacy `dragonminez:senzu` wish data.
- Allows custom Dragon Ball sets to summon with the stars declared by their definition instead of requiring exactly seven.
- Resolves custom dragons through `entity_registry_name` while keeping the logical definition ID for saved state and wishes.
- Keeps custom wish files addressable by both the dragon definition ID and `wish_screen_id`.
- Accepts the legacy `multi_wish` tuple format used by custom packs.
- Avoids consuming Dragon Balls when the configured dragon entity cannot be spawned.

## Root causes

- The summoning check was hard-coded to `foundBalls.size() == 7`.
- Entity lookup used the logical dragon ID instead of the registered entity name.
- Wish files are keyed by the definition ID, while the client and grant packet look up `wish_screen_id`.
- Existing world wish files could retain the old Senzu item ID.
- The old `multi_wish` `a`/`b` format was not parsed safely across mappings.

## Verification

Passed:

- `./gradlew compileJava compileTestJava --no-daemon`
- `./gradlew jarJar --no-daemon`
- `git diff --cached --check`
- Pure Java regression harness for three-ball sets and Senzu ID migration
- Pure Java harness for legacy and modern `multi_wish` fields
- Static scan of added lines for secrets, shell injection, eval/exec, and unsafe deserialization
- `graphify update .`
- Reobfuscated Jar-in-Jar artifact inspection, including changed classes and `META-INF/mods.toml`
- Follow-up commit `dbf936f3` rejects malformed entity registry names and `multi_wish` item data during parsing

Blocked in the local environment:

- `./gradlew test --no-daemon` compiles the tests but fails during JUnit discovery before executing them because the repository's JUnit Platform engine and Gradle launcher versions are unaligned (`OutputDirectoryCreator not available`). A temporary local check with JUnit 6.1.3 reproduced the same launcher mismatch.

CI status:

- GitHub Actions run [31899607444](https://github.com/DragonMineZ/dragonminez/actions/runs/31899607444) passed compilation, resource generation, `jar`, `jarJar`, and test compilation, then failed at `:test`. The public workflow log does not include individual test names or the XML report. Locally, the same test task fails during JUnit discovery with `OutputDirectoryCreator not available`, including a temporary check with JUnit 6.1.3.
- Follow-up run [31900483774](https://github.com/DragonMineZ/dragonminez/actions/runs/31900483774) on `dbf936f3` reproduced the same result: all build and packaging tasks passed, then `:test` failed without a published test report.
- The repository already has the separate dependency-update PR [#270](https://github.com/DragonMineZ/dragonminez/pull/270), which is intentionally not duplicated in this bugfix PR.

## Scope notes

- The existing 1 through 7 `DragonBallType` model is unchanged. This fix supports fewer declared balls using the existing star types; arbitrary star values remain outside this PR.
- Custom `entity_registry_name` values must refer to a registered `DragonWishEntity` type. This PR does not dynamically register arbitrary entities from JSON.
- #105 is a separate feature request for unique training minigames and is intentionally not included in this bugfix PR.

## Risk

The change is limited to Dragon Ball completion, custom dragon entity resolution, wish loading compatibility, and the default/persisted Senzu item ID. Invalid custom entity definitions now leave the Dragon Balls untouched instead of consuming them without a summon.