### PR TITLE
Fix: Correct racial skill descriptions and refactor text resolution

### DIFF
--- a/src/main/java/com/dragonminez/client/gui/character/RaceSelectionScreen.java
+++ b/src/main/java/com/dragonminez/client/gui/character/RaceSelectionScreen.java
@@ -15,6 +15,7 @@ import com.dragonminez.common.network.NetworkHandler;
 import com.dragonminez.common.stats.character.Character;
 import com.dragonminez.common.stats.StatsCapability;
 import com.dragonminez.common.stats.StatsProvider;
+import com.dragonminez.common.util.RacialSkillTextHelper;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
@@ -318,47 +319,8 @@ public class RaceSelectionScreen extends ScaledScreen {
 		String racialSkill = ConfigManager.getRaceCharacter(currentRace).getRacialSkill();
 		if (racialSkill == null || racialSkill.isEmpty()) return;
 
-		String titleKey = "skill.dragonminez.racial_" + racialSkill;
-		String descKey = "skill.dragonminez.racial_" + racialSkill + ".desc";
-
-		Component titleComp = tr(titleKey);
-		String description = "";
-
-		switch (racialSkill) {
-			case "human" -> {
-				int regen = (int) Math.round((config.getHumanKiRegenBoost() - 1.0) * 100);
-				description = tr(descKey, regen).getString();
-			}
-			case "saiyan" -> {
-				int zenkaiHealth = (int) Math.round(config.getSaiyanZenkaiHealthRegen() * 100);
-				int zenkaiStat = (int) Math.round(config.getSaiyanZenkaiStatBoost() * 100);
-				int cooldown = config.getSaiyanZenkaiCooldownSeconds();
-				int maxUses = config.getSaiyanZenkaiAmount();
-				description = tr(descKey, zenkaiHealth, zenkaiStat, cooldown, maxUses).getString();
-			}
-			case "namekian" -> {
-				int assimHealth = (int) Math.round(config.getNamekianAssimilationHealthRegen() * 100);
-				int assimStat = (int) Math.round(config.getNamekianAssimilationStatBoost() * 100);
-				int maxUses = config.getNamekianAssimilationAmount();
-				description = tr(descKey, assimHealth, assimStat, maxUses).getString();
-			}
-			case "frostdemon" -> {
-				int tpBoost = (int) Math.round((config.getFrostDemonTPBoost() - 1.0) * 100);
-				description = tr(descKey, tpBoost).getString();
-			}
-			case "bioandroid" -> {
-				int drainRatio = (int) Math.round(config.getBioAndroidDrainRatio() * 100);
-				int cooldown = config.getBioAndroidCooldownSeconds();
-				description = tr(descKey, drainRatio, cooldown).getString();
-			}
-			case "majin" -> {
-				int absHealth = (int) Math.round(config.getMajinAbsorptionHealthRegen() * 100);
-				int absStat = (int) Math.round(config.getMajinAbsorptionStatCopy() * 100);
-				int maxUses = config.getMajinAbsorptionAmount();
-				description = tr(descKey, absHealth, absStat, maxUses).getString();
-			}
-			default -> description = tr(descKey).getString();
-		}
+		Component titleComp = txt(RacialSkillTextHelper.getRacialSkillTitle(racialSkill));
+		String description = RacialSkillTextHelper.getRacialSkillDescription(racialSkill, config);
 
 		int uiWidth = getUiWidth();
 		int uiHeight = getUiHeight();

--- a/src/main/java/com/dragonminez/client/gui/character/SkillsMenuScreen.java
+++ b/src/main/java/com/dragonminez/client/gui/character/SkillsMenuScreen.java
@@ -23,6 +23,7 @@ import com.dragonminez.common.stats.character.Status;
 import com.dragonminez.common.stats.skills.Skill;
 import com.dragonminez.common.stats.skills.Skills;
 import com.dragonminez.common.stats.techniques.*;
+import com.dragonminez.common.util.RacialSkillTextHelper;
 import com.dragonminez.common.util.TransformationsHelper;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.ChatFormatting;
@@ -1237,41 +1238,7 @@ public class SkillsMenuScreen extends BaseMenuScreen {
 		if (isClassPassive) {
 			description = tr("class.dragonminez." + statsData.getCharacter().getCharacterClass() + ".passive.desc").getString();
 		} else if (selectedSkill.startsWith("racial_")) {
-			switch (selectedSkill) {
-				case "racial_human" -> {
-					int regen = (int) Math.round((config.getHumanKiRegenBoost() - 1.0) * 100);
-					description = tr("skill.dragonminez.racial_human.desc", regen).getString();
-				}
-				case "racial_saiyan" -> {
-					int zenkaiHealth = (int) Math.round((config.getSaiyanZenkaiHealthRegen() * 100));
-					int zenkaiStat = (int) Math.round((config.getSaiyanZenkaiStatBoost() * 100));
-					int cooldown = config.getSaiyanZenkaiCooldownSeconds();
-					int maxUses = config.getSaiyanZenkaiAmount();
-					int minLevel = config.getSaiyanZenkaiMinLevel();
-					description = tr("skill.dragonminez.racial_saiyan.desc", zenkaiHealth, zenkaiStat, cooldown, maxUses, minLevel).getString();
-				}
-				case "racial_namekian" -> {
-					int assimHealth = (int) Math.round(config.getNamekianAssimilationHealthRegen() * 100);
-					int assimStat = (int) Math.round(config.getNamekianAssimilationStatBoost() * 100);
-					int maxUses = config.getNamekianAssimilationAmount();
-					description = tr("skill.dragonminez.racial_namekian.desc", assimHealth, assimStat, maxUses).getString();
-				}
-				case "racial_frostdemon" -> {
-					int tpBoost = (int) Math.round((config.getFrostDemonTPBoost() - 1.0) * 100);
-					description = tr("skill.dragonminez.racial_frostdemon.desc", tpBoost).getString();
-				}
-				case "racial_bioandroid" -> {
-					int drainRatio = (int) Math.round(config.getBioAndroidDrainRatio() * 100);
-					int cooldown = config.getBioAndroidCooldownSeconds();
-					description = tr("skill.dragonminez.racial_bioandroid.desc", drainRatio, cooldown).getString();
-				}
-				case "racial_majin" -> {
-					int absHealth = (int) Math.round(config.getMajinAbsorptionHealthRegen() * 100);
-					int absStat = (int) Math.round(config.getMajinAbsorptionStatCopy() * 100);
-					int maxUses = config.getMajinAbsorptionAmount();
-					description = tr("skill.dragonminez.racial_majin.desc", absHealth, absStat, maxUses).getString();
-				}
-			}
+			description = RacialSkillTextHelper.getRacialSkillDescription(selectedSkill, config);
 		} else description = tr("skill.dragonminez." + selectedSkill + ".desc").getString();
 
 		int startY = panelY + 40;

--- a/src/main/java/com/dragonminez/common/util/RacialSkillTextHelper.java
+++ b/src/main/java/com/dragonminez/common/util/RacialSkillTextHelper.java
@@ -1,0 +1,60 @@
+package com.dragonminez.common.util;
+
+import com.dragonminez.common.config.GeneralServerConfig;
+import net.minecraft.network.chat.Component;
+
+// Shared racial-skill title/description resolution, used by RaceSelectionScreen and SkillsMenuScreen.
+public class RacialSkillTextHelper {
+
+	private static final String PREFIX = "racial_";
+
+	private static String stripPrefix(String racialSkill) {
+		return racialSkill.startsWith(PREFIX) ? racialSkill.substring(PREFIX.length()) : racialSkill;
+	}
+
+	public static String getRacialSkillTitle(String racialSkill) {
+		return Component.translatable("skill.dragonminez.racial_" + stripPrefix(racialSkill)).getString();
+	}
+
+	public static String getRacialSkillDescription(String racialSkill, GeneralServerConfig.RacialSkillsConfig config) {
+		String skill = stripPrefix(racialSkill);
+		String descKey = "skill.dragonminez.racial_" + skill + ".desc";
+
+		return switch (skill) {
+			case "human" -> {
+				int regen = (int) Math.round((config.getHumanKiRegenBoost() - 1.0) * 100);
+				yield Component.translatable(descKey, regen).getString();
+			}
+			case "saiyan" -> {
+				int zenkaiHealth = (int) Math.round(config.getSaiyanZenkaiHealthRegen() * 100);
+				int zenkaiStat = (int) Math.round(config.getSaiyanZenkaiStatBoost() * 100);
+				int cooldown = config.getSaiyanZenkaiCooldownSeconds();
+				int maxUses = config.getSaiyanZenkaiAmount();
+				int minLevel = config.getSaiyanZenkaiMinLevel();
+				yield Component.translatable(descKey, zenkaiHealth, zenkaiStat, cooldown, maxUses, minLevel).getString();
+			}
+			case "namekian" -> {
+				int assimHealth = (int) Math.round(config.getNamekianAssimilationHealthRegen() * 100);
+				int assimStat = (int) Math.round(config.getNamekianAssimilationStatBoost() * 100);
+				int maxUses = config.getNamekianAssimilationAmount();
+				yield Component.translatable(descKey, assimHealth, assimStat, maxUses).getString();
+			}
+			case "frostdemon" -> {
+				int tpBoost = (int) Math.round((config.getFrostDemonTPBoost() - 1.0) * 100);
+				yield Component.translatable(descKey, tpBoost).getString();
+			}
+			case "bioandroid" -> {
+				int drainRatio = (int) Math.round(config.getBioAndroidDrainRatio() * 100);
+				int cooldown = config.getBioAndroidCooldownSeconds();
+				yield Component.translatable(descKey, drainRatio, cooldown).getString();
+			}
+			case "majin" -> {
+				int absHealth = (int) Math.round(config.getMajinAbsorptionHealthRegen() * 100);
+				int absStat = (int) Math.round(config.getMajinAbsorptionStatCopy() * 100);
+				int maxUses = config.getMajinAbsorptionAmount();
+				yield Component.translatable(descKey, absHealth, absStat, maxUses).getString();
+			}
+			default -> Component.translatable(descKey).getString();
+		};
+	}
+}


### PR DESCRIPTION
## Description

Fixes racial skill descriptions displaying unresolved placeholders in-game.

The Saiyan Zenkai skill description contains five dynamic values, but the code was only providing four arguments when resolving the translation. This caused the final placeholder for the minimum required level to remain unresolved.

The missing `minLevel` value is now passed to the translation component.

### Refactor

Added `RacialSkillTextHelper` to centralize racial skill title and description resolution.

Previously, `RaceSelectionScreen` and `SkillsMenuScreen` contained duplicated logic for resolving racial skill titles and descriptions, including configuration-dependent values for each race.

The new helper provides:

- Shared racial skill title resolution.
- Shared racial skill description resolution.
- Centralized handling of racial skill configuration values.
- Removal of duplicated logic between `RaceSelectionScreen` and `SkillsMenuScreen`.

## Testing

- Tested the changes in the Forge development client.
- Verified that the Saiyan Zenkai description displays all configured values correctly.
- Verified the racial skill text in the affected screens.